### PR TITLE
feat: telemt-xray relay pipeline

### DIFF
--- a/common/filter-proxy-users.nix
+++ b/common/filter-proxy-users.nix
@@ -1,0 +1,20 @@
+# common/filter-proxy-users.nix
+#
+# Filters singBoxUsers by the `hosts` property for a given hostname.
+#   hosts = "*"           → allowed everywhere (also the default when absent)
+#   hosts = "veles"       → only on veles
+#   hosts = ["veles", "buyan"] → only on veles and buyan
+{ lib }:
+hostname: users:
+builtins.filter (
+  u:
+  let
+    h = u.hosts or "*";
+  in
+  if h == "*" then
+    true
+  else if builtins.isList h then
+    builtins.elem hostname h
+  else
+    h == hostname
+) users

--- a/docs/superpowers/plans/2026-04-14-telemt-xray-relay-pipeline.md
+++ b/docs/superpowers/plans/2026-04-14-telemt-xray-relay-pipeline.md
@@ -1,0 +1,761 @@
+# Telemt-Xray Relay Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route telemt (MTProxy) traffic through xray relay's SOCKS5 inbound to reach buyan via VLESS, and universally filter `singBoxUsers` by hostname.
+
+**Architecture:** A shared `filterProxyUsersForHost` function filters `singBoxUsers` by a new `hosts` property. The xray relay gains a localhost SOCKS5 inbound routed to its existing balancer. Telemt gets an optional `upstream` setting to route through that SOCKS5. Veles wires everything together.
+
+**Tech Stack:** NixOS modules, Nix language, xray-core, telemt
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `common/filter-proxy-users.nix` | `filterProxyUsersForHost` function |
+| Modify | `secrets/secrets.dummy.json` | Add `hosts` field to `singBoxUsers` entries |
+| Modify | `roles/network/xray/server.nix` | Use `filterProxyUsersForHost` |
+| Modify | `roles/network/xray/relay.nix` | Use `filterProxyUsersForHost` + SOCKS5 inbound + options |
+| Modify | `roles/network/xray/subscriptions.nix` | Use `filterProxyUsersForHost` |
+| Modify | `roles/network/sing-box/server.nix` | Use `filterProxyUsersForHost` |
+| Modify | `roles/network/mtproxy.nix` | Add `upstream` option, generate `[[upstreams]]` block |
+| Modify | `machines/veles/default.nix` | Enable relay + socks + mtproxy upstream |
+
+---
+
+### Task 1: Create `filterProxyUsersForHost`
+
+**Files:**
+- Create: `common/filter-proxy-users.nix`
+
+- [ ] **Step 1: Create the filtering function**
+
+Create `common/filter-proxy-users.nix`:
+
+```nix
+# common/filter-proxy-users.nix
+#
+# Filters singBoxUsers by the `hosts` property for a given hostname.
+#   hosts = "*"           → allowed everywhere (also the default when absent)
+#   hosts = "veles"       → only on veles
+#   hosts = ["veles", "buyan"] → only on veles and buyan
+{ lib }:
+hostname: users:
+builtins.filter (
+  u:
+  let
+    h = u.hosts or "*";
+  in
+  if h == "*" then
+    true
+  else if builtins.isList h then
+    builtins.elem hostname h
+  else
+    h == hostname
+) users
+```
+
+- [ ] **Step 2: Verify it evaluates correctly**
+
+Run:
+```bash
+cd /Users/o__ni/Code/Git/my-nix
+nix-instantiate --eval --strict -E '
+  let
+    lib = import <nixpkgs/lib>;
+    filter = import ./common/filter-proxy-users.nix { inherit lib; };
+    users = [
+      { name = "alice"; hosts = "*"; }
+      { name = "bob"; hosts = "veles"; }
+      { name = "carol"; hosts = ["veles" "buyan"]; }
+      { name = "dave"; hosts = "buyan"; }
+    ];
+  in map (u: u.name) (filter "veles" users)
+'
+```
+
+Expected: `[ "alice" "bob" "carol" ]`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add common/filter-proxy-users.nix
+git commit -m "feat: add filterProxyUsersForHost helper"
+```
+
+---
+
+### Task 2: Update secrets dummy schema
+
+**Files:**
+- Modify: `secrets/secrets.dummy.json`
+
+- [ ] **Step 1: Add `hosts` field to dummy singBoxUsers entry**
+
+In `secrets/secrets.dummy.json`, change the `singBoxUsers` entry from:
+
+```json
+"singBoxUsers": [
+  {
+    "uuid": "00000000-0000-0000-0000-000000000000",
+    "name": "dummy",
+    "password": "dummypassword"
+  }
+]
+```
+
+to:
+
+```json
+"singBoxUsers": [
+  {
+    "uuid": "00000000-0000-0000-0000-000000000000",
+    "name": "dummy",
+    "password": "dummypassword",
+    "hosts": "*"
+  }
+]
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add secrets/secrets.dummy.json
+git commit -m "chore(secrets): add hosts field to singBoxUsers dummy schema"
+```
+
+---
+
+### Task 3: Wire `filterProxyUsersForHost` into xray server
+
+**Files:**
+- Modify: `roles/network/xray/server.nix:14-33`
+
+- [ ] **Step 1: Replace direct `secrets.singBoxUsers` with filtered users**
+
+In `roles/network/xray/server.nix`, replace the `let` block's user references. Change lines 14-33 from:
+
+```nix
+let
+  cfg = config.roles.xray.server;
+  secrets = import ../../../secrets;
+  transports = import ./transports { inherit lib; };
+  transportList = lib.attrValues transports;
+
+  shortIds = secrets.xray.reality.shortIds or [ ];
+
+  clients = {
+    withFlow = map (u: {
+      id = u.uuid;
+      flow = "xtls-rprx-vision";
+      email = "${u.name}@xray";
+    }) secrets.singBoxUsers;
+
+    noFlow = map (u: {
+      id = u.uuid;
+      email = "${u.name}@xray";
+    }) secrets.singBoxUsers;
+  };
+```
+
+to:
+
+```nix
+let
+  cfg = config.roles.xray.server;
+  secrets = import ../../../secrets;
+  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
+  transports = import ./transports { inherit lib; };
+  transportList = lib.attrValues transports;
+
+  shortIds = secrets.xray.reality.shortIds or [ ];
+  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
+
+  clients = {
+    withFlow = map (u: {
+      id = u.uuid;
+      flow = "xtls-rprx-vision";
+      email = "${u.name}@xray";
+    }) users;
+
+    noFlow = map (u: {
+      id = u.uuid;
+      email = "${u.name}@xray";
+    }) users;
+  };
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add roles/network/xray/server.nix
+git commit -m "feat(xray/server): filter singBoxUsers by hostname"
+```
+
+---
+
+### Task 4: Wire `filterProxyUsersForHost` into xray relay
+
+**Files:**
+- Modify: `roles/network/xray/relay.nix:15-35`
+
+- [ ] **Step 1: Replace direct `secrets.singBoxUsers` with filtered users**
+
+In `roles/network/xray/relay.nix`, change lines 15-35 from:
+
+```nix
+let
+  cfg = config.roles.xray.relay;
+  serverCfg = config.roles.xray.server;
+  secrets = import ../../../secrets;
+  transports = import ./transports { inherit lib; };
+  transportList = lib.attrValues transports;
+
+  shortIds = secrets.xray.reality.shortIds or [ ];
+
+  clients = {
+    withFlow = map (u: {
+      id = u.uuid;
+      flow = "xtls-rprx-vision";
+      email = "${u.name}@xray";
+    }) secrets.singBoxUsers;
+
+    noFlow = map (u: {
+      id = u.uuid;
+      email = "${u.name}@xray";
+    }) secrets.singBoxUsers;
+  };
+```
+
+to:
+
+```nix
+let
+  cfg = config.roles.xray.relay;
+  serverCfg = config.roles.xray.server;
+  secrets = import ../../../secrets;
+  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
+  transports = import ./transports { inherit lib; };
+  transportList = lib.attrValues transports;
+
+  shortIds = secrets.xray.reality.shortIds or [ ];
+  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
+
+  clients = {
+    withFlow = map (u: {
+      id = u.uuid;
+      flow = "xtls-rprx-vision";
+      email = "${u.name}@xray";
+    }) users;
+
+    noFlow = map (u: {
+      id = u.uuid;
+      email = "${u.name}@xray";
+    }) users;
+  };
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add roles/network/xray/relay.nix
+git commit -m "feat(xray/relay): filter singBoxUsers by hostname"
+```
+
+---
+
+### Task 5: Wire `filterProxyUsersForHost` into xray subscriptions
+
+**Files:**
+- Modify: `roles/network/xray/subscriptions.nix:19-24,100-107`
+
+- [ ] **Step 1: Add filter import and filtered users variable**
+
+In `roles/network/xray/subscriptions.nix`, change lines 19-24 from:
+
+```nix
+let
+  cfg = config.roles.xray.subscriptions;
+  serverCfg = config.roles.xray.server;
+  secrets = import ../../../secrets;
+  transports = import ./transports { inherit lib; };
+  transportList = lib.attrValues transports;
+```
+
+to:
+
+```nix
+let
+  cfg = config.roles.xray.subscriptions;
+  serverCfg = config.roles.xray.server;
+  secrets = import ../../../secrets;
+  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
+  transports = import ./transports { inherit lib; };
+  transportList = lib.attrValues transports;
+  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
+```
+
+- [ ] **Step 2: Replace `secrets.singBoxUsers` with `users` in subscription generation**
+
+In the same file, change line 106 from:
+
+```nix
+        '') secrets.singBoxUsers
+```
+
+to:
+
+```nix
+        '') users
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add roles/network/xray/subscriptions.nix
+git commit -m "feat(xray/subscriptions): filter singBoxUsers by hostname"
+```
+
+---
+
+### Task 6: Wire `filterProxyUsersForHost` into sing-box server
+
+**Files:**
+- Modify: `roles/network/sing-box/server.nix:10-12,32-35,48-51,65-68`
+
+- [ ] **Step 1: Add filter import and filtered users variable**
+
+In `roles/network/sing-box/server.nix`, change lines 10-12 from:
+
+```nix
+let
+  cfg = config.roles.sing-box-server;
+  secrets = import ../../../secrets;
+```
+
+to:
+
+```nix
+let
+  cfg = config.roles.sing-box-server;
+  secrets = import ../../../secrets;
+  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
+  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
+```
+
+- [ ] **Step 2: Replace all `secrets.singBoxUsers` references with `users`**
+
+In the same file, there are three occurrences of `secrets.singBoxUsers` (lines 32-35, 48-51, 65-68). Replace each one:
+
+Line 32-35 (vless-ws users):
+```nix
+          users = map (u: {
+            name = u.name;
+            uuid = u.uuid;
+          }) secrets.singBoxUsers;
+```
+becomes:
+```nix
+          users = map (u: {
+            name = u.name;
+            uuid = u.uuid;
+          }) users;
+```
+
+Line 48-51 (vless-grpc users):
+```nix
+          users = map (u: {
+            name = u.name;
+            uuid = u.uuid;
+          }) secrets.singBoxUsers;
+```
+becomes:
+```nix
+          users = map (u: {
+            name = u.name;
+            uuid = u.uuid;
+          }) users;
+```
+
+Line 65-68 (naive users):
+```nix
+          users = map (u: {
+            username = u.name;
+            password = u.password;
+          }) secrets.singBoxUsers;
+```
+becomes:
+```nix
+          users = map (u: {
+            username = u.name;
+            password = u.password;
+          }) users;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add roles/network/sing-box/server.nix
+git commit -m "feat(sing-box/server): filter singBoxUsers by hostname"
+```
+
+---
+
+### Task 7: Add SOCKS5 inbound to xray relay
+
+**Files:**
+- Modify: `roles/network/xray/relay.nix:40-85,88-127`
+
+- [ ] **Step 1: Add SOCKS5 inbound to relayConfig**
+
+In `roles/network/xray/relay.nix`, change the `relayConfig` block (lines 40-85). Add the SOCKS5 inbound and routing rule.
+
+Change line 41 (inbounds) from:
+
+```nix
+    inbounds = map (
+```
+
+to:
+
+```nix
+    inbounds = lib.optionals cfg.socks.enable [
+      {
+        listen = "127.0.0.1";
+        port = cfg.socks.port;
+        protocol = "socks";
+        tag = "socks-relay-in";
+        settings = {
+          auth = "noauth";
+          udp = true;
+        };
+      }
+    ] ++ map (
+```
+
+Change the routing rules (lines 61-68) from:
+
+```nix
+      rules = lib.optionals (enabledInbound != [ ]) [
+        {
+          type = "field";
+          inboundTag = map (
+            t: if t.name == "vlessGrpc" then "vless-grpcFwd-in" else "${t.tagPrefix}-fwd-in"
+          ) enabledInbound;
+          balancerTag = "relay-balancer";
+        }
+      ];
+```
+
+to:
+
+```nix
+      rules = lib.optionals cfg.socks.enable [
+        {
+          type = "field";
+          inboundTag = [ "socks-relay-in" ];
+          balancerTag = "relay-balancer";
+        }
+      ] ++ lib.optionals (enabledInbound != [ ]) [
+        {
+          type = "field";
+          inboundTag = map (
+            t: if t.name == "vlessGrpc" then "vless-grpcFwd-in" else "${t.tagPrefix}-fwd-in"
+          ) enabledInbound;
+          balancerTag = "relay-balancer";
+        }
+      ];
+```
+
+- [ ] **Step 2: Add SOCKS5 options**
+
+In the same file, add the `socks` option block. Change lines 88-89 from:
+
+```nix
+  options.roles.xray.relay = {
+    enable = mkEnableOption "relay traffic to another xray server";
+```
+
+to:
+
+```nix
+  options.roles.xray.relay = {
+    enable = mkEnableOption "relay traffic to another xray server";
+
+    socks = {
+      enable = mkEnableOption "local SOCKS5 inbound for relay";
+      port = mkOption {
+        type = types.port;
+        default = 1080;
+        description = "SOCKS5 listen port on 127.0.0.1";
+      };
+    };
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add roles/network/xray/relay.nix
+git commit -m "feat(xray/relay): add localhost SOCKS5 inbound option"
+```
+
+---
+
+### Task 8: Add upstream option to mtproxy module
+
+**Files:**
+- Modify: `roles/network/mtproxy.nix:17-44,47-69`
+
+- [ ] **Step 1: Add upstream to generated telemt.toml**
+
+In `roles/network/mtproxy.nix`, change the `configFile` definition (lines 17-44) from:
+
+```nix
+  configFile = pkgs.writeText "telemt.toml" ''
+    [general]
+    use_middle_proxy = true
+    log_level = "normal"
+
+    [general.modes]
+    classic = false
+    secure = false
+    tls = true
+
+    [server]
+    port = ${toString cfg.port}
+    proxy_protocol = true
+
+    [[server.listeners]]
+    ip = "127.0.0.1"
+
+    [censorship]
+    tls_domain = "${cfg.tls.domain}"
+    mask = true
+    tls_emulation = true
+    tls_front_dir = "/var/lib/telemt/tlsfront"
+
+    [access.users]
+    ${lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: secret: ''${name} = "${secret}"'') cfg.users
+    )}
+  '';
+```
+
+to:
+
+```nix
+  configFile = pkgs.writeText "telemt.toml" (''
+    [general]
+    use_middle_proxy = true
+    log_level = "normal"
+
+    [general.modes]
+    classic = false
+    secure = false
+    tls = true
+
+    [server]
+    port = ${toString cfg.port}
+    proxy_protocol = true
+
+    [[server.listeners]]
+    ip = "127.0.0.1"
+
+    [censorship]
+    tls_domain = "${cfg.tls.domain}"
+    mask = true
+    tls_emulation = true
+    tls_front_dir = "/var/lib/telemt/tlsfront"
+
+    [access.users]
+    ${lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: secret: ''${name} = "${secret}"'') cfg.users
+    )}
+  '' + lib.optionalString (cfg.upstream != null) ''
+
+    [[upstreams]]
+    type = "socks5"
+    address = "${cfg.upstream}"
+  '');
+```
+
+- [ ] **Step 2: Add upstream option**
+
+In the same file, add the `upstream` option after the `users` option. Change lines 62-69 from:
+
+```nix
+    users = mkOption {
+      type = types.attrsOf types.str;
+      description = "Map of username to 32-char hex secret";
+      example = {
+        alice = "00000000000000000000000000000001";
+      };
+    };
+  };
+```
+
+to:
+
+```nix
+    users = mkOption {
+      type = types.attrsOf types.str;
+      description = "Map of username to 32-char hex secret";
+      example = {
+        alice = "00000000000000000000000000000001";
+      };
+    };
+
+    upstream = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "SOCKS5 upstream address (host:port). Null = direct via middle proxies.";
+      example = "127.0.0.1:1080";
+    };
+  };
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add roles/network/mtproxy.nix
+git commit -m "feat(mtproxy): add optional SOCKS5 upstream for telemt"
+```
+
+---
+
+### Task 9: Wire veles machine config
+
+**Files:**
+- Modify: `machines/veles/default.nix:66-91`
+
+- [ ] **Step 1: Enable relay with SOCKS5 and configure mtproxy upstream**
+
+In `machines/veles/default.nix`, change lines 66-91 from:
+
+```nix
+  roles.xray = {
+    enable = true;
+    server = {
+      enable = true;
+      reality.privateKeyFile = "/etc/nixos/secrets/xray-reality-private-key";
+      vlessTcp = {
+        enable = true;
+        sni = "api.oneme.ru";
+      };
+      vlessGrpc = {
+        enable = true;
+        sni = "avatars.mds.yandex.net";
+      };
+      vlessXhttp = {
+        enable = true;
+        sni = "onlymir.ru";
+      };
+    };
+  };
+
+  roles.mtproxy = {
+    enable = true;
+    tls.domain = "api.ok.ru";
+    port = 9100;
+    users = secrets.mtproxy.users;
+  };
+```
+
+to:
+
+```nix
+  roles.xray = {
+    enable = true;
+    server = {
+      enable = true;
+      reality.privateKeyFile = "/etc/nixos/secrets/xray-reality-private-key";
+      vlessTcp = {
+        enable = true;
+        sni = "api.oneme.ru";
+      };
+      vlessGrpc = {
+        enable = true;
+        sni = "avatars.mds.yandex.net";
+      };
+      vlessXhttp = {
+        enable = true;
+        sni = "onlymir.ru";
+      };
+    };
+    relay = {
+      enable = true;
+      socks.enable = true;
+      user = builtins.head secrets.singBoxUsers;
+      target = {
+        server = secrets.ip.buyan.address;
+        reality = {
+          publicKey = secrets.xray.buyan.reality.publicKey;
+          shortId = builtins.head (secrets.xray.reality.shortIds);
+        };
+        vlessTcp = {
+          enable = true;
+          serverName = "ghcr.io";
+        };
+        vlessGrpc = {
+          enable = true;
+          serverName = "update.googleapis.com";
+        };
+        vlessXhttp = {
+          enable = true;
+          serverName = "dl.google.com";
+        };
+      };
+    };
+  };
+
+  roles.mtproxy = {
+    enable = true;
+    tls.domain = "api.ok.ru";
+    port = 9100;
+    upstream = "127.0.0.1:1080";
+    users = secrets.mtproxy.users;
+  };
+```
+
+> **Note to implementor:** The `secrets.xray.buyan.reality.publicKey` path assumes this key exists in `secrets.json`. The actual path may differ — check the real secrets structure and adjust. The relay `user` should also be a user whose `hosts` includes `"veles"` (or `"*"`). The relay target `serverName` values must match buyan's xray server SNIs exactly (confirmed from `machines/buyan/default.nix`).
+
+- [ ] **Step 2: Verify the config evaluates**
+
+Run:
+```bash
+cd /Users/o__ni/Code/Git/my-nix
+nix eval .#nixosConfigurations.veles.config.roles.xray.relay.enable 2>&1 | head -20
+```
+
+Expected: `true` (or a meaningful error about missing secrets, not a Nix syntax/type error)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add machines/veles/default.nix
+git commit -m "feat(veles): enable xray relay to buyan + mtproxy SOCKS5 upstream"
+```
+
+---
+
+### Task 10: Update secrets.json with hosts + buyan reality key
+
+**Files:**
+- Modify: `secrets/secrets.json` (encrypted — must be decrypted, edited, re-encrypted)
+
+> **Note to implementor:** This task requires GPG access to decrypt `secrets.json.gpg`. The changes needed are:
+> 1. Add `"hosts": "*"` (or appropriate value) to each entry in `singBoxUsers`
+> 2. Add buyan's Reality public key at a path like `xray.buyan.reality.publicKey` (or wherever the veles config references it)
+> 3. Re-encrypt and commit
+
+This task may need to be done manually by the repo owner.
+
+- [ ] **Step 1: Decrypt, add `hosts` to all singBoxUsers entries, add buyan reality pubkey**
+- [ ] **Step 2: Re-encrypt and commit**
+
+```bash
+git add secrets/secrets.json.gpg
+git commit -m "chore(secrets): add hosts to singBoxUsers + buyan reality pubkey"
+```

--- a/docs/superpowers/specs/2026-04-14-telemt-xray-relay-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-14-telemt-xray-relay-pipeline-design.md
@@ -1,0 +1,163 @@
+# Telemt-Xray Relay Pipeline Design
+
+## Goal
+
+Route Telegram MTProxy (telemt) traffic through xray relay to achieve:
+
+```
+client -- mtproxy --> veles[telemt] -- socks5 --> veles[xray relay] -- vless --> buyan
+```
+
+## Changes
+
+### 1. Universal user filtering: `filterProxyUsersForHost`
+
+**File:** `common/filter-proxy-users.nix` (new)
+
+A pure function that filters `singBoxUsers` entries by the `hosts` property matched against a machine's hostname.
+
+```nix
+{ lib }:
+hostname: users:
+  builtins.filter (u:
+    let h = u.hosts or "*"; in
+    if h == "*" then true
+    else if builtins.isList h then builtins.elem hostname h
+    else h == hostname
+  ) users
+```
+
+**`hosts` semantics:**
+- `"*"` (or absent) — user provisioned on all machines
+- `"veles"` — only on veles
+- `["veles", "buyan"]` — only on veles and buyan
+
+**Consumers to update** (switch from `secrets.singBoxUsers` to `filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers`):
+- `roles/network/xray/server.nix`
+- `roles/network/xray/relay.nix`
+- `roles/network/xray/subscriptions.nix`
+- `roles/network/sing-box/server.nix`
+
+**Scope:** Only `singBoxUsers`. MTProxy users (`secrets.mtproxy.users`) are not filtered.
+
+### 2. Relay SOCKS5 inbound
+
+**File:** `roles/network/xray/relay.nix` (modify)
+
+Add options:
+
+```nix
+roles.xray.relay.socks = {
+  enable = mkEnableOption "local SOCKS5 inbound for relay";
+  port = mkOption { type = types.port; default = 1080; };
+};
+```
+
+When enabled, add to relay's xray config:
+
+**Inbound:**
+```json
+{
+  "listen": "127.0.0.1",
+  "port": 1080,
+  "protocol": "socks",
+  "tag": "socks-relay-in",
+  "settings": { "auth": "noauth", "udp": true }
+}
+```
+
+**Routing rule:**
+```json
+{
+  "type": "field",
+  "inboundTag": ["socks-relay-in"],
+  "balancerTag": "relay-balancer"
+}
+```
+
+The SOCKS5 inbound shares the existing `relay-balancer` (leastPing across all enabled outbound transports to the target server).
+
+### 3. Telemt upstream option
+
+**File:** `roles/network/mtproxy.nix` (modify)
+
+Add option:
+
+```nix
+roles.mtproxy.upstream = mkOption {
+  type = types.nullOr types.str;
+  default = null;
+  description = "SOCKS5 upstream address (e.g. 127.0.0.1:1080). Null = direct connection.";
+};
+```
+
+When `upstream != null`, append to generated `telemt.toml`:
+
+```toml
+[[upstreams]]
+type = "socks5"
+address = "127.0.0.1:1080"
+```
+
+When `upstream == null`, no `[[upstreams]]` section (current behavior).
+
+### 4. Secrets schema update
+
+**File:** `secrets/secrets.json` (modify)
+
+Add `hosts` property to each `singBoxUsers` entry:
+
+```json
+{
+  "uuid": "...",
+  "name": "alice",
+  "password": "...",
+  "hosts": "*"
+}
+```
+
+Type: `string | string[]`
+
+### 5. Veles machine wiring
+
+**File:** `machines/veles/default.nix` (modify)
+
+Enable relay targeting buyan with SOCKS5, and configure telemt upstream:
+
+```nix
+roles.xray = {
+  enable = true;
+  server = {
+    enable = true;
+    reality.privateKeyFile = "/etc/nixos/secrets/xray-reality-private-key";
+    vlessTcp  = { enable = true; sni = "api.oneme.ru"; };
+    vlessGrpc = { enable = true; sni = "avatars.mds.yandex.net"; };
+    vlessXhttp = { enable = true; sni = "onlymir.ru"; };
+  };
+  relay = {
+    enable = true;
+    socks.enable = true;
+    user = /* first filtered user or specific user */;
+    target = {
+      server = secrets.ip.buyan.address;
+      reality = { /* buyan's Reality public key, shortId, etc. */ };
+      vlessTcp.enable = true;
+      vlessGrpc.enable = true;
+      vlessXhttp.enable = true;
+    };
+  };
+};
+
+roles.mtproxy = {
+  enable = true;
+  tls.domain = "api.ok.ru";
+  upstream = "127.0.0.1:1080";
+  users = secrets.mtproxy.users;
+};
+```
+
+## Out of scope
+
+- Filtering `secrets.mtproxy.users` by host (separate user structure)
+- Per-user upstream routing in telemt (all users share the same upstream)
+- Auth on the SOCKS5 inbound (localhost-only is sufficient)

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
           {
             nixpkgs.overlays = (import ./overlays) ++ [
               (final: prev: {
-                telemt = nixpkgs-unstable.legacyPackages.${prev.system}.telemt;
+                telemt = nixpkgs-unstable.legacyPackages.${prev.stdenv.hostPlatform.system}.telemt;
               })
             ];
           }

--- a/machines/buyan/default.nix
+++ b/machines/buyan/default.nix
@@ -1,9 +1,12 @@
-{ ... }:
+{ lib, ... }:
 
 let
   hostname = "buyan";
   ifname = "ens3";
   ip = (import ../../secrets).ip.buyan;
+  secrets = import ../../secrets;
+  filterProxyUsersForHost = import ../../common/filter-proxy-users.nix { inherit lib; };
+  users = filterProxyUsersForHost hostname secrets.singBoxUsers;
 in
 {
   imports = [
@@ -66,6 +69,7 @@ in
     enable = true;
     server = {
       enable = true;
+      users = users;
       reality.privateKeyFile = "/etc/nixos/secrets/xray-reality-private-key";
       vlessTcp = {
         enable = true;

--- a/machines/mokosh/default.nix
+++ b/machines/mokosh/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 
 let
   hostname = "mokosh";
@@ -9,6 +9,9 @@ let
   };
   ifname = "ens3";
   ip = (import ../../secrets).ip.mokosh;
+  filterProxyUsersForHost = import ../../common/filter-proxy-users.nix { inherit lib; };
+  secrets = import ../../secrets;
+  users = filterProxyUsersForHost hostname secrets.singBoxUsers;
 in
 {
   imports = [
@@ -193,6 +196,7 @@ in
 
   roles.sing-box-server = {
     enable = true;
+    users = users;
     baseDomain = domainNames.primary;
     enableFallback = false;
 

--- a/machines/veles/default.nix
+++ b/machines/veles/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   ...
 }:
 
@@ -6,6 +7,8 @@ let
   hostname = "veles";
   secrets = import ../../secrets;
   mokoshIp = secrets.ip.mokosh.address;
+  filterProxyUsersForHost = import ../../common/filter-proxy-users.nix { inherit lib; };
+  users = filterProxyUsersForHost hostname secrets.singBoxUsers;
 in
 {
   imports = [
@@ -67,6 +70,7 @@ in
     enable = true;
     server = {
       enable = true;
+      users = users;
       reality.privateKeyFile = "/etc/nixos/secrets/xray-reality-private-key";
       vlessTcp = {
         enable = true;
@@ -83,6 +87,7 @@ in
     };
     relay = {
       enable = true;
+      users = users;
       socks.enable = true;
       vlessTcp.sni = "www.apple.com";
       vlessGrpc.sni = "grpc.google.com";

--- a/machines/veles/default.nix
+++ b/machines/veles/default.nix
@@ -81,12 +81,37 @@ in
         sni = "onlymir.ru";
       };
     };
+    relay = {
+      enable = true;
+      socks.enable = true;
+      user = builtins.head secrets.singBoxUsers;
+      target = {
+        server = secrets.ip.buyan.address;
+        reality = {
+          publicKey = secrets.xray.buyan.reality.publicKey;
+          shortId = builtins.head (secrets.xray.reality.shortIds);
+        };
+        vlessTcp = {
+          enable = true;
+          serverName = "ghcr.io";
+        };
+        vlessGrpc = {
+          enable = true;
+          serverName = "update.googleapis.com";
+        };
+        vlessXhttp = {
+          enable = true;
+          serverName = "dl.google.com";
+        };
+      };
+    };
   };
 
   roles.mtproxy = {
     enable = true;
     tls.domain = "api.ok.ru";
     port = 9100;
+    upstream = "127.0.0.1:1080";
     users = secrets.mtproxy.users;
   };
 

--- a/machines/veles/default.nix
+++ b/machines/veles/default.nix
@@ -84,6 +84,9 @@ in
     relay = {
       enable = true;
       socks.enable = true;
+      vlessTcp.sni = "www.apple.com";
+      vlessGrpc.sni = "grpc.google.com";
+      vlessXhttp.sni = "www.cloudflare.com";
       user = builtins.head secrets.singBoxUsers;
       target = {
         server = secrets.ip.buyan.address;

--- a/roles/network/mtproxy.nix
+++ b/roles/network/mtproxy.nix
@@ -14,39 +14,42 @@ with lib;
 let
   cfg = config.roles.mtproxy;
 
-  configFile = pkgs.writeText "telemt.toml" (''
-    [general]
-    use_middle_proxy = true
-    log_level = "normal"
+  configFile = pkgs.writeText "telemt.toml" (
+    ''
+      [general]
+      use_middle_proxy = true
+      log_level = "normal"
 
-    [general.modes]
-    classic = false
-    secure = false
-    tls = true
+      [general.modes]
+      classic = false
+      secure = false
+      tls = true
 
-    [server]
-    port = ${toString cfg.port}
-    proxy_protocol = true
+      [server]
+      port = ${toString cfg.port}
+      proxy_protocol = true
 
-    [[server.listeners]]
-    ip = "127.0.0.1"
+      [[server.listeners]]
+      ip = "127.0.0.1"
 
-    [censorship]
-    tls_domain = "${cfg.tls.domain}"
-    mask = true
-    tls_emulation = true
-    tls_front_dir = "/var/lib/telemt/tlsfront"
+      [censorship]
+      tls_domain = "${cfg.tls.domain}"
+      mask = true
+      tls_emulation = true
+      tls_front_dir = "/var/lib/telemt/tlsfront"
 
-    [access.users]
-    ${lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (name: secret: ''${name} = "${secret}"'') cfg.users
-    )}
-  '' + lib.optionalString (cfg.upstream != null) ''
+      [access.users]
+      ${lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (name: secret: ''${name} = "${secret}"'') cfg.users
+      )}
+    ''
+    + lib.optionalString (cfg.upstream != null) ''
 
-    [[upstreams]]
-    type = "socks5"
-    address = "${cfg.upstream}"
-  '');
+      [[upstreams]]
+      type = "socks5"
+      address = "${cfg.upstream}"
+    ''
+  );
 in
 {
   options.roles.mtproxy = {

--- a/roles/network/mtproxy.nix
+++ b/roles/network/mtproxy.nix
@@ -14,7 +14,7 @@ with lib;
 let
   cfg = config.roles.mtproxy;
 
-  configFile = pkgs.writeText "telemt.toml" ''
+  configFile = pkgs.writeText "telemt.toml" (''
     [general]
     use_middle_proxy = true
     log_level = "normal"
@@ -41,7 +41,12 @@ let
     ${lib.concatStringsSep "\n" (
       lib.mapAttrsToList (name: secret: ''${name} = "${secret}"'') cfg.users
     )}
-  '';
+  '' + lib.optionalString (cfg.upstream != null) ''
+
+    [[upstreams]]
+    type = "socks5"
+    address = "${cfg.upstream}"
+  '');
 in
 {
   options.roles.mtproxy = {
@@ -65,6 +70,13 @@ in
       example = {
         alice = "00000000000000000000000000000001";
       };
+    };
+
+    upstream = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "SOCKS5 upstream address (host:port). Null = direct via middle proxies.";
+      example = "127.0.0.1:1080";
     };
   };
 

--- a/roles/network/sing-box/server.nix
+++ b/roles/network/sing-box/server.nix
@@ -10,6 +10,8 @@ with lib;
 let
   cfg = config.roles.sing-box-server;
   secrets = import ../../../secrets;
+  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
+  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
 
   vlessWsPort = 9000;
   vlessGrpcPort = 9001;
@@ -32,7 +34,7 @@ let
           users = map (u: {
             name = u.name;
             uuid = u.uuid;
-          }) secrets.singBoxUsers;
+          }) users;
           transport = {
             type = "ws";
             path = cfg.vlessWs.path;
@@ -48,7 +50,7 @@ let
           users = map (u: {
             name = u.name;
             uuid = u.uuid;
-          }) secrets.singBoxUsers;
+          }) users;
           transport = {
             type = "grpc";
             service_name = cfg.vlessGrpc.serviceName;
@@ -65,7 +67,7 @@ let
           users = map (u: {
             username = u.name;
             password = u.password;
-          }) secrets.singBoxUsers;
+          }) users;
           tls = {
             enabled = true;
             server_name = "gw.${cfg.baseDomain}";

--- a/roles/network/sing-box/server.nix
+++ b/roles/network/sing-box/server.nix
@@ -9,9 +9,6 @@ with lib;
 
 let
   cfg = config.roles.sing-box-server;
-  secrets = import ../../../secrets;
-  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
-  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
 
   vlessWsPort = 9000;
   vlessGrpcPort = 9001;
@@ -34,7 +31,7 @@ let
           users = map (u: {
             name = u.name;
             uuid = u.uuid;
-          }) users;
+          }) cfg.users;
           transport = {
             type = "ws";
             path = cfg.vlessWs.path;
@@ -50,7 +47,7 @@ let
           users = map (u: {
             name = u.name;
             uuid = u.uuid;
-          }) users;
+          }) cfg.users;
           transport = {
             type = "grpc";
             service_name = cfg.vlessGrpc.serviceName;
@@ -67,7 +64,7 @@ let
           users = map (u: {
             username = u.name;
             password = u.password;
-          }) users;
+          }) cfg.users;
           tls = {
             enabled = true;
             server_name = "gw.${cfg.baseDomain}";
@@ -92,6 +89,12 @@ in
 {
   options.roles.sing-box-server = {
     enable = mkEnableOption "sing-box anti-censorship proxy server";
+
+    users = mkOption {
+      type = types.listOf types.attrs;
+      default = [ ];
+      description = "Proxy users to allow. Each entry must have at least { name, uuid, password }.";
+    };
 
     baseDomain = mkOption {
       type = types.str;

--- a/roles/network/xray/relay.nix
+++ b/roles/network/xray/relay.nix
@@ -16,22 +16,24 @@ let
   cfg = config.roles.xray.relay;
   serverCfg = config.roles.xray.server;
   secrets = import ../../../secrets;
+  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
   transports = import ./transports { inherit lib; };
   transportList = lib.attrValues transports;
 
   shortIds = secrets.xray.reality.shortIds or [ ];
+  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
 
   clients = {
     withFlow = map (u: {
       id = u.uuid;
       flow = "xtls-rprx-vision";
       email = "${u.name}@xray";
-    }) secrets.singBoxUsers;
+    }) users;
 
     noFlow = map (u: {
       id = u.uuid;
       email = "${u.name}@xray";
-    }) secrets.singBoxUsers;
+    }) users;
   };
 
   enabledInbound = lib.filter (t: serverCfg.${t.name}.enable) transportList;

--- a/roles/network/xray/relay.nix
+++ b/roles/network/xray/relay.nix
@@ -40,7 +40,18 @@ let
   enabledOutbound = lib.filter (t: cfg.target.${t.name}.enable) transportList;
 
   relayConfig = {
-    inbounds = map (
+    inbounds = lib.optionals cfg.socks.enable [
+      {
+        listen = "127.0.0.1";
+        port = cfg.socks.port;
+        protocol = "socks";
+        tag = "socks-relay-in";
+        settings = {
+          auth = "noauth";
+          udp = true;
+        };
+      }
+    ] ++ map (
       t:
       t.mkRelayInbound {
         cfg = cfg.${t.name};
@@ -60,7 +71,13 @@ let
     ) enabledOutbound;
 
     routing = {
-      rules = lib.optionals (enabledInbound != [ ]) [
+      rules = lib.optionals cfg.socks.enable [
+        {
+          type = "field";
+          inboundTag = [ "socks-relay-in" ];
+          balancerTag = "relay-balancer";
+        }
+      ] ++ lib.optionals (enabledInbound != [ ]) [
         {
           type = "field";
           inboundTag = map (
@@ -89,6 +106,15 @@ in
 {
   options.roles.xray.relay = {
     enable = mkEnableOption "relay traffic to another xray server";
+
+    socks = {
+      enable = mkEnableOption "local SOCKS5 inbound for relay";
+      port = mkOption {
+        type = types.port;
+        default = 1080;
+        description = "SOCKS5 listen port on 127.0.0.1";
+      };
+    };
 
     user = mkOption {
       type = types.attrs;

--- a/roles/network/xray/relay.nix
+++ b/roles/network/xray/relay.nix
@@ -16,24 +16,22 @@ let
   cfg = config.roles.xray.relay;
   serverCfg = config.roles.xray.server;
   secrets = import ../../../secrets;
-  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
   transports = import ./transports { inherit lib; };
   transportList = lib.attrValues transports;
 
   shortIds = secrets.xray.reality.shortIds or [ ];
-  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
 
   clients = {
     withFlow = map (u: {
       id = u.uuid;
       flow = "xtls-rprx-vision";
       email = "${u.name}@xray";
-    }) users;
+    }) cfg.users;
 
     noFlow = map (u: {
       id = u.uuid;
       email = "${u.name}@xray";
-    }) users;
+    }) cfg.users;
   };
 
   enabledInbound = lib.filter (t: serverCfg.${t.name}.enable) transportList;
@@ -110,6 +108,12 @@ in
 {
   options.roles.xray.relay = {
     enable = mkEnableOption "relay traffic to another xray server";
+
+    users = mkOption {
+      type = types.listOf types.attrs;
+      default = [ ];
+      description = "Proxy users to allow for relay inbounds. Each entry must have at least { name, uuid }.";
+    };
 
     socks = {
       enable = mkEnableOption "local SOCKS5 inbound for relay";

--- a/roles/network/xray/relay.nix
+++ b/roles/network/xray/relay.nix
@@ -165,8 +165,8 @@ in
         message = "At least one relay target transport must be enabled (roles.xray.relay.target.<transport>.enable)";
       }
       {
-        assertion = enabledInbound != [ ];
-        message = "At least one server transport must be enabled for relay inbounds";
+        assertion = cfg.socks.enable || enabledInbound != [ ];
+        message = "At least one relay inbound must be enabled: either socks.enable = true or at least one server transport must be active";
       }
     ];
 

--- a/roles/network/xray/relay.nix
+++ b/roles/network/xray/relay.nix
@@ -40,25 +40,27 @@ let
   enabledOutbound = lib.filter (t: cfg.target.${t.name}.enable) transportList;
 
   relayConfig = {
-    inbounds = lib.optionals cfg.socks.enable [
-      {
-        listen = "127.0.0.1";
-        port = cfg.socks.port;
-        protocol = "socks";
-        tag = "socks-relay-in";
-        settings = {
-          auth = "noauth";
-          udp = true;
-        };
-      }
-    ] ++ map (
-      t:
-      t.mkRelayInbound {
-        cfg = cfg.${t.name};
-        serverCfg = serverCfg.${t.name};
-        inherit clients shortIds;
-      }
-    ) enabledInbound;
+    inbounds =
+      lib.optionals cfg.socks.enable [
+        {
+          listen = "127.0.0.1";
+          port = cfg.socks.port;
+          protocol = "socks";
+          tag = "socks-relay-in";
+          settings = {
+            auth = "noauth";
+            udp = true;
+          };
+        }
+      ]
+      ++ map (
+        t:
+        t.mkRelayInbound {
+          cfg = cfg.${t.name};
+          serverCfg = serverCfg.${t.name};
+          inherit clients shortIds;
+        }
+      ) enabledInbound;
 
     outbounds = map (
       t:
@@ -71,21 +73,23 @@ let
     ) enabledOutbound;
 
     routing = {
-      rules = lib.optionals cfg.socks.enable [
-        {
-          type = "field";
-          inboundTag = [ "socks-relay-in" ];
-          balancerTag = "relay-balancer";
-        }
-      ] ++ lib.optionals (enabledInbound != [ ]) [
-        {
-          type = "field";
-          inboundTag = map (
-            t: if t.name == "vlessGrpc" then "vless-grpcFwd-in" else "${t.tagPrefix}-fwd-in"
-          ) enabledInbound;
-          balancerTag = "relay-balancer";
-        }
-      ];
+      rules =
+        lib.optionals cfg.socks.enable [
+          {
+            type = "field";
+            inboundTag = [ "socks-relay-in" ];
+            balancerTag = "relay-balancer";
+          }
+        ]
+        ++ lib.optionals (enabledInbound != [ ]) [
+          {
+            type = "field";
+            inboundTag = map (
+              t: if t.name == "vlessGrpc" then "vless-grpcFwd-in" else "${t.tagPrefix}-fwd-in"
+            ) enabledInbound;
+            balancerTag = "relay-balancer";
+          }
+        ];
       balancers = lib.optionals (enabledOutbound != [ ]) [
         {
           tag = "relay-balancer";

--- a/roles/network/xray/server.nix
+++ b/roles/network/xray/server.nix
@@ -14,22 +14,24 @@ with lib;
 let
   cfg = config.roles.xray.server;
   secrets = import ../../../secrets;
+  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
   transports = import ./transports { inherit lib; };
   transportList = lib.attrValues transports;
 
   shortIds = secrets.xray.reality.shortIds or [ ];
+  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
 
   clients = {
     withFlow = map (u: {
       id = u.uuid;
       flow = "xtls-rprx-vision";
       email = "${u.name}@xray";
-    }) secrets.singBoxUsers;
+    }) users;
 
     noFlow = map (u: {
       id = u.uuid;
       email = "${u.name}@xray";
-    }) secrets.singBoxUsers;
+    }) users;
   };
 
   enabledTransports = lib.filter (t: cfg.${t.name}.enable) transportList;

--- a/roles/network/xray/server.nix
+++ b/roles/network/xray/server.nix
@@ -14,24 +14,22 @@ with lib;
 let
   cfg = config.roles.xray.server;
   secrets = import ../../../secrets;
-  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
   transports = import ./transports { inherit lib; };
   transportList = lib.attrValues transports;
 
   shortIds = secrets.xray.reality.shortIds or [ ];
-  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
 
   clients = {
     withFlow = map (u: {
       id = u.uuid;
       flow = "xtls-rprx-vision";
       email = "${u.name}@xray";
-    }) users;
+    }) cfg.users;
 
     noFlow = map (u: {
       id = u.uuid;
       email = "${u.name}@xray";
-    }) users;
+    }) cfg.users;
   };
 
   enabledTransports = lib.filter (t: cfg.${t.name}.enable) transportList;
@@ -72,6 +70,12 @@ in
 {
   options.roles.xray.server = {
     enable = mkEnableOption "xray anti-censorship proxy server with Reality";
+
+    users = mkOption {
+      type = types.listOf types.attrs;
+      default = [ ];
+      description = "Proxy users to allow. Each entry must have at least { name, uuid }.";
+    };
 
     reality = {
       privateKeyFile = mkOption {

--- a/roles/network/xray/subscriptions.nix
+++ b/roles/network/xray/subscriptions.nix
@@ -20,10 +20,8 @@ let
   cfg = config.roles.xray.subscriptions;
   serverCfg = config.roles.xray.server;
   secrets = import ../../../secrets;
-  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
   transports = import ./transports { inherit lib; };
   transportList = lib.attrValues transports;
-  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
 
   coLocated = config.roles.xray.enable && serverCfg.enable;
 
@@ -33,6 +31,12 @@ in
 {
   options.roles.xray.subscriptions = {
     enable = mkEnableOption "serve per-user xray subscriptions over HTTPS";
+
+    users = mkOption {
+      type = types.listOf types.attrs;
+      default = [ ];
+      description = "Proxy users to generate subscriptions for. Each entry must have at least { name, uuid }.";
+    };
 
     sni = mkOption {
       type = types.str;
@@ -105,7 +109,7 @@ in
         ''
         + lib.concatMapStrings (u: ''
           printf '%s' ${lib.escapeShellArg (userUrisText u)} | base64 -w0 > $out/${u.uuid}
-        '') users
+        '') cfg.users
       );
     in
     {

--- a/roles/network/xray/subscriptions.nix
+++ b/roles/network/xray/subscriptions.nix
@@ -20,8 +20,10 @@ let
   cfg = config.roles.xray.subscriptions;
   serverCfg = config.roles.xray.server;
   secrets = import ../../../secrets;
+  filterProxyUsersForHost = import ../../../common/filter-proxy-users.nix { inherit lib; };
   transports = import ./transports { inherit lib; };
   transportList = lib.attrValues transports;
+  users = filterProxyUsersForHost config.networking.hostName secrets.singBoxUsers;
 
   coLocated = config.roles.xray.enable && serverCfg.enable;
 
@@ -103,7 +105,7 @@ in
         ''
         + lib.concatMapStrings (u: ''
           printf '%s' ${lib.escapeShellArg (userUrisText u)} | base64 -w0 > $out/${u.uuid}
-        '') secrets.singBoxUsers
+        '') users
       );
     in
     {

--- a/secrets/secrets.dummy.json
+++ b/secrets/secrets.dummy.json
@@ -22,6 +22,11 @@
   "xray": {
     "reality": {
       "shortIds": ["deadbeef12345678"]
+    },
+    "buyan": {
+      "reality": {
+        "publicKey": "dummyBuyanRealityPublicKeyxxxxxxxxxxxxxxxx"
+      }
     }
   },
   "wireguard": {

--- a/secrets/secrets.dummy.json
+++ b/secrets/secrets.dummy.json
@@ -15,7 +15,8 @@
     {
       "uuid": "00000000-0000-0000-0000-000000000000",
       "name": "dummy",
-      "password": "dummypassword"
+      "password": "dummypassword",
+      "hosts": "*"
     }
   ],
   "xray": {


### PR DESCRIPTION
## Summary

- Add `filterProxyUsersForHost` helper (`common/filter-proxy-users.nix`) to filter `singBoxUsers` by a `hosts` property, and wire it into xray server, relay, subscriptions, and sing-box server
- Add localhost SOCKS5 inbound option (`roles.xray.relay.socks`) to xray relay so telemt can route through it
- Add `upstream` option to mtproxy module to forward telemt traffic through a SOCKS5 proxy
- Wire veles: enable relay to buyan with SOCKS5, set `roles.mtproxy.upstream = "127.0.0.1:1080"`

## Architecture

```
client -- mtproxy --> veles[telemt] -- socks5 --> veles[xray relay] -- vless --> buyan
```

## Test Plan

- [ ] `nix eval .#nixosConfigurations.veles.config.roles.xray.relay.enable` → `true`
- [ ] `nix eval .#nixosConfigurations.veles.config.roles.mtproxy.upstream` → `"127.0.0.1:1080"`
- [ ] Add `hosts` field to real `secrets.json` singBoxUsers entries and buyan reality pubkey (Task 10 — manual, requires GPG)
- [ ] Deploy to veles and verify telemt traffic routes through xray relay to buyan