### PR TITLE
fix: declare backup directories via systemd tmpfiles

### DIFF
--- a/common/sqlite-backup.nix
+++ b/common/sqlite-backup.nix
@@ -23,6 +23,10 @@ let
   '';
 in
 {
+  systemd.tmpfiles.rules = [
+    "d ${backupDir} 0750 ${user} ${group} -"
+  ];
+
   systemd.services."backup-${name}" = {
     description = "Backup ${name}";
     path = [ pkgs.sqlite ];
@@ -33,7 +37,6 @@ in
       Group = group;
       ExecStart = pkgs.writeShellScript "backup-${name}" ''
         set -euo pipefail
-        mkdir -p ${backupDir}
         ${extraPathsCmd}
         ${backupCmds}
       '';

--- a/roles/reading/rss/backup.nix
+++ b/roles/reading/rss/backup.nix
@@ -12,6 +12,10 @@ let
 in
 {
   config = mkIf cfg.enable {
+    systemd.tmpfiles.rules = [
+      "d ${backupDir} 0750 postgres postgres -"
+    ];
+
     systemd.services.backup-miniflux = {
       description = "Backup Miniflux PostgreSQL database";
       path = [ pkgs.postgresql_16 ];
@@ -20,7 +24,6 @@ in
         Type = "oneshot";
         ExecStart = pkgs.writeShellScript "backup-miniflux" ''
           set -euo pipefail
-          mkdir -p ${backupDir}
           pg_dump miniflux | gzip > ${backupDir}/miniflux.sql.gz.tmp
           mv ${backupDir}/miniflux.sql.gz.tmp ${backupDir}/miniflux.sql.gz
         '';


### PR DESCRIPTION
## Summary
- Add `systemd.tmpfiles.rules` to `mkSqliteBackup` so backup directories are pre-created with correct ownership (`0750 user group`)
- Add tmpfiles rule for miniflux backup dir as well
- Remove redundant `mkdir -p` from backup scripts

Fixes permission errors like `mkdir: cannot create directory '/var/backup/calibre': Permission denied` — no more manual directory creation needed.