### PR TITLE
fix: use --s3-endpoint-url for duplicity Yandex Cloud S3

### DIFF
--- a/machines/mokosh/default.nix
+++ b/machines/mokosh/default.nix
@@ -233,7 +233,11 @@ in
     enable = true;
     gpgPublicKey = ../../common/backup-gpg-public.asc;
     gpgKeyId = "AC99246D656181EFE5BF18C9D4C62D97193EF180";
-    targetUrl = "s3://storage.yandexcloud.net/wellwineo-backups/mokosh";
+    targetUrl = "s3:///wellwineo-backups/mokosh";
+    extraFlags = [
+      "--s3-endpoint-url=https://storage.yandexcloud.net"
+      "--s3-region-name=ru-central1"
+    ];
   };
 
   system.stateVersion = "25.11";


### PR DESCRIPTION
## Summary
- Change `targetUrl` to `s3:///wellwineo-backups/mokosh` (triple slash — duplicity ignores S3 URL hostnames)
- Add `--s3-endpoint-url=https://storage.yandexcloud.net` and `--s3-region-name=ru-central1` via `extraFlags`
- Fixes duplicity connecting to `s3.ru-central1.amazonaws.com` instead of Yandex Cloud