### PR TITLE
feat(mokosh): add DigitalOcean image and stage mokosh cutover

### DIFF
--- a/.github/workflows/build-do-image.yml
+++ b/.github/workflows/build-do-image.yml
@@ -1,7 +1,15 @@
-name: Build DigitalOcean image
+name: Build cloud image
 
 on:
   workflow_dispatch:
+    inputs:
+      cloud:
+        description: Target cloud provider
+        required: true
+        type: choice
+        default: digitalocean
+        options:
+          - digitalocean
 
 jobs:
   build:
@@ -23,21 +31,32 @@ jobs:
       - name: Set up dummy secrets
         run: make setup-dummy-secrets
 
-      - name: Build DO image
+      - name: Resolve nix attribute
         run: |
-          OUT=$(nix build \
-            'path:.#nixosConfigurations.do-generic.config.system.build.digitalOceanImage' \
-            --no-link --print-out-paths)
+          case "${{ inputs.cloud }}" in
+            digitalocean)
+              echo "NIX_ATTR=path:.#nixosConfigurations.do-generic.config.system.build.digitalOceanImage" >> "$GITHUB_ENV"
+              echo "IMAGE_GLOB=*.qcow2*"    >> "$GITHUB_ENV"
+              echo "ARTIFACT=nixos.qcow2"   >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "Unknown cloud: ${{ inputs.cloud }}" && exit 1
+              ;;
+          esac
+
+      - name: Build image
+        run: |
+          OUT=$(nix build "$NIX_ATTR" --no-link --print-out-paths)
           echo "IMAGE_OUT=$OUT" >> "$GITHUB_ENV"
 
       - name: Collect artifact
         run: |
-          IMAGE=$(find "$IMAGE_OUT" -name '*.qcow2*' | head -1)
-          cp -L "$IMAGE" nixos.qcow2
-          ls -lh nixos.qcow2
+          IMAGE=$(find "$IMAGE_OUT" -name "$IMAGE_GLOB" | head -1)
+          cp -L "$IMAGE" "$ARTIFACT"
+          ls -lh "$ARTIFACT"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: nixos-do-image
-          path: nixos.qcow2
+          name: nixos-${{ inputs.cloud }}-image
+          path: ${{ env.ARTIFACT }}
           retention-days: 7

--- a/.github/workflows/build-do-image.yml
+++ b/.github/workflows/build-do-image.yml
@@ -1,0 +1,43 @@
+name: Build DigitalOcean image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Set up dummy secrets
+        run: make setup-dummy-secrets
+
+      - name: Build DO image
+        run: |
+          OUT=$(nix build \
+            'path:.#nixosConfigurations.do-generic.config.system.build.digitalOceanImage' \
+            --no-link --print-out-paths)
+          echo "IMAGE_OUT=$OUT" >> "$GITHUB_ENV"
+
+      - name: Collect artifact
+        run: |
+          IMAGE=$(find "$IMAGE_OUT" -name '*.qcow2*' | head -1)
+          cp -L "$IMAGE" nixos.qcow2
+          ls -lh nixos.qcow2
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nixos-do-image
+          path: nixos.qcow2
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -162,6 +162,35 @@ To add a new role, create a `.nix` file in `roles/` — no import registration n
 3. Import `../../roles` and enable needed roles
 4. Set `system.stateVersion = "25.11"`
 
+## Bootstrapping a DigitalOcean Droplet
+
+A generic DO-bootable qcow2 image is exposed as a flake package. The image
+contains a minimal NixOS with SSH, the operator user, the binary cache, and
+cloud-init for network configuration from DO metadata. It does **not** bake
+in any machine's role set — apply the per-machine config after first boot.
+
+```bash
+# Build (x86_64 Linux host, or via remote builder from macOS)
+nix build .#do-image
+
+# Upload result/nixos.qcow2 to DigitalOcean → Images → Custom Images,
+# then create a droplet from that custom image.
+
+# SSH in as the operator user (cloud-init populates networking from DO metadata):
+ssh o__ni@<droplet-ip>
+
+# On the droplet: clone this flake, install secrets, switch to the machine config.
+git clone <this-repo> ~/my-nix && cd ~/my-nix
+make unlock
+sudo make install-secrets
+sudo hostnamectl set-hostname <machine>   # e.g. mokosh
+sudo make switch
+```
+
+The image is generic — the same artifact can bootstrap any x86_64 NixOS
+machine in this flake. The `make switch` step picks the machine config from
+`$(hostname)`.
+
 ## Adding a New Role
 
 1. Create `roles/<name>.nix` (or `roles/<category>/<name>.nix`)

--- a/docs/mokosh-do-migration.md
+++ b/docs/mokosh-do-migration.md
@@ -1,0 +1,142 @@
+# Migrating mokosh to DigitalOcean via nixos-infect
+
+## Prerequisites
+
+- DigitalOcean account
+- SSH key added to DO
+- GPG key available to decrypt secrets
+- Branch `feat/mokosh-do-image` checked out locally
+
+---
+
+## Step 1: Create the droplet
+
+On DigitalOcean:
+- **Image**: Ubuntu 22.04 x86_64
+- **Size**: at least 1 CPU, 2 GB RAM (match current mokosh specs)
+- **SSH key**: add your key so you can log in as root
+- Note the droplet IP
+
+---
+
+## Step 2: Run nixos-infect
+
+```bash
+ssh root@<droplet-ip>
+
+curl https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | \
+  NIX_CHANNEL=nixos-25.11 bash -x 2>&1 | tee /tmp/infect.log
+```
+
+Takes ~5–10 min. Reboots automatically into NixOS when done.
+
+---
+
+## Step 3: Fix disk layout after reboot
+
+The mokosh config expects `/dev/disk/by-label/NIXOS` — relabel the root partition:
+
+```bash
+ssh root@<droplet-ip>
+
+lsblk -f  # find root device, usually /dev/vda1
+
+ROOT_DEV=$(findmnt -n -o SOURCE /)
+e2label $ROOT_DEV NIXOS
+```
+
+DO droplets have no swap partition — create a swapfile:
+
+```bash
+fallocate -l 1G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+```
+
+---
+
+## Step 4: Update mokosh config for swapfile
+
+On your Mac, edit `machines/mokosh/default.nix` on the branch.
+
+Replace:
+```nix
+swapDevices = [ { device = "/dev/disk/by-label/SWAP"; } ];
+```
+
+With:
+```nix
+swapDevices = [ { device = "/swapfile"; } ];
+```
+
+Commit and push:
+```bash
+git add machines/mokosh/default.nix
+git commit -m "fix(mokosh): use swapfile instead of swap partition for DO"
+git push
+```
+
+---
+
+## Step 5: Set up the flake on the droplet
+
+```bash
+ssh root@<droplet-ip>
+
+nix-env -iA nixos.git
+git clone https://github.com/wellWINeo/my-nix /root/my-nix
+cd /root/my-nix
+git checkout feat/mokosh-do-image
+```
+
+---
+
+## Step 6: Transfer secrets
+
+On your Mac — copy encrypted secrets to the droplet:
+```bash
+scp secrets/secrets.json.gpg secrets/locked.tar.gpg root@<droplet-ip>:/root/my-nix/secrets/
+```
+
+Transfer your GPG key:
+```bash
+gpg --export-secret-keys <key-id> | ssh root@<droplet-ip> 'gpg --import'
+```
+
+On the droplet, unlock secrets:
+```bash
+cd /root/my-nix && make unlock
+```
+
+---
+
+## Step 7: Switch to mokosh config
+
+```bash
+cd /root/my-nix
+hostnamectl set-hostname mokosh
+nixos-rebuild switch --flake 'path:.#mokosh'
+```
+
+> **Networking note**: the switch sets `networking.useDHCP = false` and hands
+> networking to the DO metadata services. If SSH drops during the switch, wait
+> 60 seconds and reconnect — the DO metadata service should bring the interface
+> back up. If it doesn't, use the DO web console to recover.
+
+---
+
+## Step 8: Verify services
+
+```bash
+systemctl status nginx postfix dovecot2 vaultwarden
+```
+
+---
+
+## Step 9: Cutover and cleanup
+
+1. Update DNS A records to point at the new droplet IP
+2. Wait for TTL to propagate
+3. Merge `feat/mokosh-do-image` to `main`
+4. Decommission the old VPS

--- a/docs/superpowers/plans/2026-06-06-mokosh-do-image.md
+++ b/docs/superpowers/plans/2026-06-06-mokosh-do-image.md
@@ -1,0 +1,530 @@
+# DigitalOcean image for mokosh — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a generic DigitalOcean-bootable qcow2 image to this flake and stage the mokosh-side changes needed to run on the droplet, so mokosh can be migrated to DO via `make switch` after first boot.
+
+**Architecture:** A new `images/do-generic/` module defines DO hardware + cloud-init networking + growpart. A new `nixosConfigurations.do-generic` assembles it with the existing `common/cache.nix`, `common/server.nix`, and `users/o__ni`. A new flake package `do-image` exposes its `system.build.digitalOceanImage`. The mokosh machine config is updated on this branch to drop static IP and import the same image module, but the branch is not merged until cutover.
+
+**Tech Stack:** NixOS (nixos-25.11), Nix flakes, upstream `nixos/modules/virtualisation/digital-ocean-image.nix`, cloud-init (NixOS module), QEMU for smoke test.
+
+**Branch:** `feat/mokosh-do-image` (already created, spec committed there).
+
+**Background context for the implementer:**
+- This repo's "tests" are `nix flake check` (evaluates every `nixosConfigurations.*` and `packages.*`) and `nix build .#<attr>` (actually realizes the derivation). There is no unit test framework. Treat eval/build success + QEMU smoke as the verification step at the end of each task.
+- The repo uses `nixfmt-rfc-style` (available in `nix develop`). Run `make fmt` before committing.
+- Don't commit `result/` symlinks or build outputs.
+- The on-prem mokosh must keep working until cutover. The mokosh-side change is on this branch only and **must not be merged to main** until the droplet is verified.
+- Read the spec at `docs/superpowers/specs/2026-06-06-mokosh-do-image-design.md` before starting if you have not.
+
+---
+
+## File structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `images/do-generic/default.nix` | create | DO hardware profile: image builder import, cloud-init networking, growpart, virtio modules, GRUB on `/dev/vda`. No users, no roles. |
+| `flake.nix` | modify | Add `nixosConfigurations.do-generic` and `packages.<system>.do-image`. |
+| `README.md` | modify | Add a short "Bootstrapping a DigitalOcean droplet" subsection. |
+| `machines/mokosh/default.nix` | modify | Replace `hardware/vm.nix` import with `images/do-generic`; drop static IP block; keep hostname. **Branch only — do not merge until cutover.** |
+
+---
+
+## Task 1: Create `images/do-generic/default.nix`
+
+**Files:**
+- Create: `images/do-generic/default.nix`
+
+- [ ] **Step 1: Create the directory and file**
+
+Run:
+
+```bash
+mkdir -p images/do-generic
+```
+
+- [ ] **Step 2: Write the module**
+
+Write `images/do-generic/default.nix`:
+
+```nix
+# Generic DigitalOcean-bootable NixOS profile.
+#
+# Scope: hardware/boot/network only. No users, tooling, or roles — those come
+# from other modules (e.g. users/o__ni, common/server.nix). Importing this
+# module exposes `system.build.digitalOceanImage` (a qcow2 builder) and wires
+# the runtime bits a droplet needs: virtio drivers, growpart on the root
+# partition, and cloud-init for networking from DO metadata.
+#
+# Constraint: root filesystem must be ext4 (autoResize uses online ext4 resize).
+
+{ modulesPath, lib, ... }:
+
+{
+  imports = [
+    "${modulesPath}/virtualisation/digital-ocean-image.nix"
+  ];
+
+  boot = {
+    loader.grub = {
+      enable = true;
+      device = "/dev/vda";
+    };
+
+    growPartition = true;
+
+    initrd.availableKernelModules = [
+      "virtio_pci"
+      "virtio_scsi"
+      "virtio_blk"
+      "sd_mod"
+    ];
+  };
+
+  fileSystems."/".autoResize = true;
+
+  networking = {
+    useDHCP = false;
+    hostName = lib.mkDefault "";
+  };
+
+  services.cloud-init = {
+    enable = true;
+    network.enable = true;
+    settings.datasource_list = [
+      "DigitalOcean"
+      "None"
+    ];
+  };
+}
+```
+
+- [ ] **Step 3: Format**
+
+Run:
+
+```bash
+nix develop -c nixfmt images/do-generic/default.nix
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add images/do-generic/default.nix
+git commit -m "feat(images): add generic DigitalOcean image profile"
+```
+
+Note: this commit alone does not change `nix flake check` output because the module is not yet referenced by any `nixosConfigurations` attribute.
+
+---
+
+## Task 2: Wire `nixosConfigurations.do-generic` and `packages.do-image` into `flake.nix`
+
+**Files:**
+- Modify: `flake.nix`
+
+- [ ] **Step 1: Read the current flake**
+
+Open `flake.nix`. Locate (a) the block defining `nixosConfigurations` (around the existing `mokosh`, `veles`, `buyan`, `nixpi` entries) and (b) the `packages = forAllSystems (...)` block at the end.
+
+- [ ] **Step 2: Add the `do-generic` nixosSystem**
+
+Inside `outputs = { ... }: let ... in { ... }`, add this attribute next to the other `nixosConfigurations` entries (placement: after `buyan`, before the `homeConfigurations` block):
+
+```nix
+      # generic DigitalOcean image (any x86_64 droplet)
+      nixosConfigurations."do-generic" = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        specialArgs = inputs;
+        modules = [
+          ./common/cache.nix
+          ./common/server.nix
+          ./users/o__ni
+          ./images/do-generic
+          { system.stateVersion = "25.11"; }
+        ];
+      };
+```
+
+- [ ] **Step 3: Expose the image as a flake package**
+
+In the existing `packages = forAllSystems (system: let pkgs = nixpkgsFor.${system}; in { bulwark-webmail = pkgs.bulwark-webmail; })` block, change the inner attrset to also expose `do-image` only for `x86_64-linux`:
+
+Replace the existing `packages = ...` block at the bottom of the file with:
+
+```nix
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          bulwark-webmail = pkgs.bulwark-webmail;
+        }
+        // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          do-image = self.nixosConfigurations."do-generic".config.system.build.digitalOceanImage;
+        }
+      );
+```
+
+Note: `self` must be in scope. Check the existing `outputs = { nixpkgs, nixpkgs-unstable, ... }@inputs: ...` line — `self` is *not* currently destructured. Update that line to include `self`:
+
+```nix
+  outputs =
+    { self, nixpkgs, nixpkgs-unstable, ... }@inputs:
+```
+
+- [ ] **Step 4: Format**
+
+```bash
+nix develop -c nixfmt flake.nix
+```
+
+- [ ] **Step 5: Evaluate the flake**
+
+Run:
+
+```bash
+make check
+```
+
+Expected: command exits 0. If it errors with `attribute 'digitalOceanImage' missing`, that means the upstream module name or attribute changed — re-check `<nixpkgs>/nixos/modules/virtualisation/digital-ocean-image.nix` in the locked nixpkgs and adjust.
+
+If it errors with `attribute 'datasource_list' missing` under `services.cloud-init.settings`, the option name in the locked nixpkgs differs. Fall back to setting it via `services.cloud-init.config` raw YAML:
+
+```nix
+services.cloud-init = {
+  enable = true;
+  network.enable = true;
+  config = ''
+    datasource_list: [ DigitalOcean, None ]
+  '';
+};
+```
+
+Re-run `make check` after the fallback.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add flake.nix
+git commit -m "feat(flake): add do-generic nixosConfiguration and do-image package"
+```
+
+---
+
+## Task 3: Build the image
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Build**
+
+Run on an x86_64 Linux host (or via a remote builder from macOS):
+
+```bash
+nix build .#do-image
+```
+
+Expected: command exits 0, `result` symlink appears.
+
+- [ ] **Step 2: Inspect the artifact**
+
+```bash
+ls -lh result/
+file result/nixos.qcow2 || file result/*.qcow2 || ls result/
+```
+
+Expected: a `nixos.qcow2` (or similar) file present. Size should be in the hundreds-of-MB range (small generic NixOS + cloud-init + nix tooling).
+
+If the artifact name differs (e.g. compressed as `.qcow2.gz`), note the actual name — it will be used in Task 4.
+
+- [ ] **Step 3: No commit**
+
+Build outputs are not committed. Move to Task 4.
+
+---
+
+## Task 4: QEMU smoke test
+
+**Files:** none modified — verification only.
+
+This step requires KVM. On macOS hosts, run the build + QEMU on a Linux box (or skip and jump to Task 6's DO smoke test).
+
+- [ ] **Step 1: Boot the image**
+
+Copy the image out of the read-only Nix store so QEMU can write to it:
+
+```bash
+cp -L result/nixos.qcow2 /tmp/do-test.qcow2
+chmod u+w /tmp/do-test.qcow2
+
+qemu-system-x86_64 \
+  -m 1024 \
+  -enable-kvm \
+  -nographic \
+  -drive file=/tmp/do-test.qcow2,format=qcow2,if=virtio \
+  -nic user,hostfwd=tcp::2222-:22
+```
+
+(If the file is `nixos.qcow2.gz`, decompress first with `gunzip -k`.)
+
+Expected: console output shows kernel boot, NixOS systemd reaches multi-user.target. cloud-init will log a warning that DO metadata is unreachable and fall through to the `None` datasource — this is intentional.
+
+- [ ] **Step 2: SSH in**
+
+From another terminal on the host:
+
+```bash
+ssh -p 2222 -o StrictHostKeyChecking=no o__ni@localhost
+```
+
+Expected: login succeeds using the SSH key baked from `users/o__ni`. (If no networking is available inside the guest because cloud-init didn't configure it, this step verifies QEMU user-mode networking only — to also reach the guest, the image needs an interface up. If sshd is unreachable in QEMU, that's a known limitation for the local smoke test; this is documented as such in the spec edge-cases section and is **not** a blocker. The authoritative smoke test is Task 6 on a real droplet.)
+
+- [ ] **Step 3: Verify root resize on first boot**
+
+Inside the VM (or via SSH if reachable):
+
+```bash
+df -h /
+```
+
+Expected: root filesystem size matches the qcow2 virtual size (qemu defaults the disk to the image's virtual size, so this verifies that growpart + autoResize at least did not break boot; the dramatic resize is on DO where the droplet disk is much larger).
+
+- [ ] **Step 4: Shut down the VM**
+
+Press `Ctrl-A X` (nographic QEMU exit) or `poweroff` from inside the guest.
+
+- [ ] **Step 5: No commit**
+
+Move to documentation.
+
+---
+
+## Task 5: Document the DO bootstrap flow in README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Locate the insertion point**
+
+In `README.md`, find the `## Adding a New Machine` section (around line 158).
+
+- [ ] **Step 2: Add a new subsection**
+
+After the closing line of `## Adding a New Machine` (the bullet `4. Set system.stateVersion = "25.11"`), insert this new section. The literal content to paste is between the `````` markers below (do NOT paste the `````` markers themselves):
+
+``````
+## Bootstrapping a DigitalOcean Droplet
+
+A generic DO-bootable qcow2 image is exposed as a flake package. The image
+contains a minimal NixOS with SSH, the operator user, the binary cache, and
+cloud-init for network configuration from DO metadata. It does **not** bake
+in any machine's role set — apply the per-machine config after first boot.
+
+```bash
+# Build (x86_64 Linux host, or via remote builder from macOS)
+nix build .#do-image
+
+# Upload result/nixos.qcow2 to DigitalOcean → Images → Custom Images,
+# then create a droplet from that custom image.
+
+# SSH in as the operator user (cloud-init populates networking from DO metadata):
+ssh o__ni@<droplet-ip>
+
+# On the droplet: clone this flake, install secrets, switch to the machine config.
+git clone <this-repo> ~/my-nix && cd ~/my-nix
+make unlock
+sudo make install-secrets
+sudo hostnamectl set-hostname <machine>   # e.g. mokosh
+sudo make switch
+```
+
+The image is generic — the same artifact can bootstrap any x86_64 NixOS
+machine in this flake. The `make switch` step picks the machine config from
+`$(hostname)`.
+``````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): document DigitalOcean droplet bootstrap"
+```
+
+---
+
+## Task 6: Stage mokosh cutover edits (branch-only)
+
+**Files:**
+- Modify: `machines/mokosh/default.nix`
+
+> **Do not merge this task's commit to `main` until the droplet is up and verified.** This change breaks the on-prem mokosh because it removes the static IP block.
+
+- [ ] **Step 1: Open the file**
+
+Open `machines/mokosh/default.nix`. The relevant blocks are:
+
+- the `let` binding `ip = (import ../../secrets).ip.mokosh;` (around line 11)
+- the `imports = [ ... ../../hardware/vm.nix ... ]` block (around line 17)
+- the `networking` block with `useDHCP`, `interfaces."${ifname}"`, `defaultGateway` (around lines 38–57)
+
+- [ ] **Step 2: Replace `hardware/vm.nix` import with the DO image profile**
+
+Change:
+
+```nix
+    ../../hardware/vm.nix
+```
+
+to:
+
+```nix
+    ../../images/do-generic
+```
+
+- [ ] **Step 3: Drop the static IP block and the `ip` binding**
+
+Remove these lines from the `let` block:
+
+```nix
+  ip = (import ../../secrets).ip.mokosh;
+```
+
+Remove these lines from the `networking` block, keeping `hostName`, `nameservers`, and `firewall.enable`:
+
+```nix
+    useDHCP = false;
+
+    interfaces."${ifname}" = {
+      ipv4.addresses = [
+        {
+          address = ip.address;
+          prefixLength = 24;
+        }
+      ];
+    };
+
+    defaultGateway = {
+      address = ip.gateway;
+      interface = ifname;
+    };
+```
+
+The resulting `networking` block should be:
+
+```nix
+  networking = {
+    hostName = hostname;
+    nameservers = [ "1.1.1.1" ];
+    firewall.enable = true;
+  };
+```
+
+- [ ] **Step 4: Drop the `ifname` binding if no longer used**
+
+After removing the `interfaces."${ifname}"` and `defaultGateway` blocks, `ifname` is still used by `roles.wireguardRouter.externalIf = ifname;`. Keep the `ifname` binding. **Do not remove it.**
+
+Verify by grepping:
+
+```bash
+grep -n ifname machines/mokosh/default.nix
+```
+
+Expected: at least one remaining use under `roles.wireguardRouter.externalIf`.
+
+- [ ] **Step 5: Drop `boot.loader.grub.device`**
+
+The line:
+
+```nix
+  boot.loader.grub.device = "/dev/vda";
+```
+
+is now redundant — `images/do-generic` already sets `boot.loader.grub.device = "/dev/vda"`. Remove the mokosh-side line to avoid surprising overrides.
+
+- [ ] **Step 6: Format**
+
+```bash
+nix develop -c nixfmt machines/mokosh/default.nix
+```
+
+- [ ] **Step 7: Evaluate**
+
+```bash
+make check
+```
+
+Expected: exits 0. Both `nixosConfigurations.mokosh` and `nixosConfigurations.do-generic` evaluate.
+
+- [ ] **Step 8: Confirm the mokosh image builds too**
+
+As a bonus verification that the mokosh-side import is benign:
+
+```bash
+nix build .#nixosConfigurations.mokosh.config.system.build.digitalOceanImage --no-link
+```
+
+Expected: build completes (it produces a mokosh-flavored DO image as a side effect of the shared module). This is not a deliverable — we are not promising a baked mokosh image — but the build succeeding proves the wiring is consistent.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add machines/mokosh/default.nix
+git commit -m "feat(mokosh): switch to DO image profile, drop static IP
+
+Mokosh will receive its IP from DigitalOcean metadata via cloud-init.
+DO NOT MERGE until the droplet is provisioned and verified."
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Re-run flake check**
+
+```bash
+make check
+```
+
+Expected: exits 0.
+
+- [ ] **Step 2: Re-run do-image build**
+
+```bash
+nix build .#do-image
+```
+
+Expected: exits 0, `result/` present.
+
+- [ ] **Step 3: Confirm branch state**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: spec commit + 4 feature commits in order:
+1. `docs: design for DigitalOcean image for mokosh`
+2. `feat(images): add generic DigitalOcean image profile`
+3. `feat(flake): add do-generic nixosConfiguration and do-image package`
+4. `docs(readme): document DigitalOcean droplet bootstrap`
+5. `feat(mokosh): switch to DO image profile, drop static IP`
+
+- [ ] **Step 4: Branch handoff**
+
+The branch `feat/mokosh-do-image` is now ready for the migration. **Do not open a PR / merge to `main` yet.** The mokosh commit (#5 above) will break the on-prem mokosh as soon as it is applied via `nixos-rebuild switch`.
+
+Migration runbook (executed by the operator, not the implementer):
+
+1. `nix build .#do-image` on a Linux host.
+2. Upload `result/nixos.qcow2` to DO → Custom Images.
+3. Create droplet from the custom image.
+4. SSH in as `o__ni`. Confirm networking and shell work.
+5. `git clone` this repo; check out `feat/mokosh-do-image`.
+6. `make unlock && sudo make install-secrets`.
+7. `sudo hostnamectl set-hostname mokosh`.
+8. `sudo make switch`.
+9. Verify representative services: `systemctl status nginx postfix dovecot vaultwarden`.
+10. Update DNS to point at the droplet IP.
+11. Once verified, merge `feat/mokosh-do-image` to `main` and decommission the old VPS.

--- a/docs/superpowers/specs/2026-06-06-mokosh-do-image-design.md
+++ b/docs/superpowers/specs/2026-06-06-mokosh-do-image-design.md
@@ -1,0 +1,239 @@
+# DigitalOcean image for mokosh — design
+
+## Goal
+
+Migrate `mokosh` (currently a generic VPS) onto a DigitalOcean droplet by
+producing a DO-uploadable qcow2 NixOS image from this flake.
+
+The image itself is **generic**: it boots a minimal NixOS with SSH, the user
+account, the binary cache, and DO-aware networking. Mokosh's role set is
+applied **after** the droplet is up, via the normal flake workflow
+(`make unlock && make install-secrets && make switch`).
+
+## Non-goals
+
+- Automating first-boot `nixos-rebuild` on the droplet.
+- Baking real `/etc/nixos/secrets/*` material into the image.
+- Provisioning DO itself (creating the custom image entry, droplet, DNS) via
+  Terraform/`doctl`. Done manually for now.
+- Changing the on-prem mokosh's static-IP networking until cutover.
+
+## Approach
+
+A generic, machine-agnostic image profile under `images/do-generic/`,
+consumed by a new `nixosConfigurations.do-generic` whose
+`system.build.digitalOceanImage` is exposed as
+`packages.x86_64-linux.do-image`.
+
+Trade-off summary (recorded for future reference):
+
+- **Generic image + post-deploy `make switch` (chosen).** Image stays small
+  and reusable; never goes stale w.r.t. flake content; one artifact can
+  bootstrap any machine. Two-phase deploy is acceptable because (a) this is
+  a deliberate migration, not autoscaling, and (b) the existing S3 binary
+  cache makes the post-deploy switch fast.
+- **Baked mokosh image (rejected).** Faster first boot, but image must be
+  rebuilt on every config change to remain a valid DR artifact, and the
+  closure is large.
+
+Upstream `nixos/modules/virtualisation/digital-ocean-image.nix` is the
+canonical builder and is used directly. `nixos-generators` is not
+introduced.
+
+`nixos/modules/virtualisation/digital-ocean-config.nix` (the full DO runtime
+integration: cloud-init for SSH keys, hostname, network, droplet metadata) is
+**not** imported. We use cloud-init only for networking; SSH keys and tooling
+come from `users/o__ni`.
+
+## Components
+
+### `images/do-generic/default.nix` (new)
+
+DO image hardware + runtime profile. Scope is hardware/boot/network only;
+no users, no tooling, no roles.
+
+Responsibilities:
+
+- Import `<nixpkgs/nixos/modules/virtualisation/digital-ocean-image.nix>` to
+  expose `system.build.digitalOceanImage`.
+- `boot.loader.grub.enable = true;` with device `/dev/vda` (DO uses
+  virtio-blk).
+- `boot.growPartition = true;` and `fileSystems."/".autoResize = true;` so
+  the root partition + ext4 FS expand to the droplet's disk on first boot.
+- `boot.initrd.availableKernelModules` for virtio: `virtio_pci`,
+  `virtio_scsi`, `virtio_blk`, `sd_mod`.
+- `services.cloud-init.enable = true;` with networking enabled
+  (`services.cloud-init.network.enable = true;` on current nixpkgs).
+- Configure cloud-init's `datasource_list` to `[DigitalOcean, None]` via the
+  NixOS module's settings/config option (exact attribute name to be confirmed
+  against `nixos-25.11` at implementation time). The `None` fallback keeps
+  boot from hanging when metadata is unreachable, e.g. local QEMU smoke
+  tests.
+- `networking.useDHCP = false;` — cloud-init renders the network config from
+  DO metadata; we do not want a parallel DHCP path.
+- `networking.hostName = "";` — empty hostname so cloud-init sets it from
+  DO metadata at first boot.
+
+Does **not** set: any user, any role, any SSH config beyond defaults, any
+firewall rules beyond the base server module.
+
+### `nixosConfigurations.do-generic` in `flake.nix` (new)
+
+Small `nixpkgs.lib.nixosSystem` value:
+
+```nix
+nixosConfigurations.do-generic = nixpkgs.lib.nixosSystem {
+  system = "x86_64-linux";
+  specialArgs = inputs;
+  modules = [
+    ./common/cache.nix
+    ./common/server.nix
+    ./users/o__ni
+    ./images/do-generic
+    { system.stateVersion = "25.11"; }
+  ];
+};
+```
+
+No mokosh role imports. No `machines/mokosh` import. Reuses the existing
+operator user (which already provides `git`, `gnupg`, `gnumake`, `neovim`,
+hashed password, and authorized SSH key) and the existing S3 binary cache
+config.
+
+### `packages.x86_64-linux.do-image` in `flake.nix` (new)
+
+```nix
+do-image = self.nixosConfigurations.do-generic.config.system.build.digitalOceanImage;
+```
+
+Built locally with `nix build .#do-image`. Output: a gzipped qcow2 under
+`result/`.
+
+### `users/o__ni` (unchanged)
+
+Already provides everything we need for first-SSH bootstrap:
+
+- `users.users.o__ni` with `hashedPassword` and `openssh.authorizedKeys.keys`
+  drawn from `secrets`.
+- Packages: `git`, `gnupg`, `gnumake`, `neovim`, `htop`, `neofetch`.
+- `nix.settings.experimental-features = [ "flakes" "nix-command" ];`
+
+No edits required.
+
+### `machines/mokosh/default.nix` (changed at cutover, not as part of image work)
+
+When migration happens, the static-IP block is removed and replaced with
+reliance on cloud-init networking. Specifically:
+
+- Drop `networking.useDHCP`, `networking.interfaces."${ifname}"`, and
+  `networking.defaultGateway` (those came from `secrets.ip.mokosh`).
+- Keep `networking.hostName = "mokosh";` — the flake wins over cloud-init's
+  metadata-derived hostname after `make switch`.
+- Replace the `hardware/vm.nix` import (Hyper-V guest) with `./images/do-generic`.
+  The DO image profile's runtime bits — virtio modules, growpart, cloud-init
+  networking — are exactly what we want on the running droplet too. The
+  `digital-ocean-image.nix` upstream module only adds the
+  `system.build.digitalOceanImage` derivation; it has no other runtime
+  side effects, so importing it into mokosh's running config is harmless
+  (and convenient: rebuilding mokosh's own image becomes trivial).
+
+This change is staged on a branch and only merged once the droplet is up,
+so the on-prem mokosh keeps working in the meantime.
+
+## Data flow
+
+```
+flake.nix
+  └── nixosConfigurations.do-generic
+        ├── common/cache.nix         (S3 substituter + trusted key)
+        ├── common/server.nix        (sshd, base nginx defaults)
+        ├── users/o__ni              (operator: pubkey, gpg, make, git)
+        └── images/do-generic        (DO image builder, cloud-init net, growpart)
+              ↓
+        config.system.build.digitalOceanImage
+              ↓
+        result/nixos.qcow2.gz   →   upload to DO Custom Images
+                                →   create droplet
+                                →   cloud-init pulls IP/gateway/DNS/hostname
+                                →   sshd up, o__ni authorized
+                                →   ssh in, clone repo, install secrets, make switch
+```
+
+## Migration / cutover for mokosh
+
+Performed once the image work lands:
+
+1. Build: `nix build .#do-image` on a local x86_64 Linux host (or via remote
+   builder from macOS).
+2. Upload `result/nixos.qcow2.gz` to DO → Images → Custom Images.
+3. Create a droplet from the custom image in the desired region/size.
+4. SSH: `ssh o__ni@<droplet-ip>`.
+5. Bootstrap:
+   - `git clone <repo> /home/o__ni/my-nix && cd /home/o__ni/my-nix`
+   - Check out the branch with the mokosh static-IP removal.
+   - `make unlock` (interactive GPG passphrase).
+   - `sudo make install-secrets` (writes `/etc/nixos/secrets/*`).
+   - `sudo make switch` — picks `nixosConfigurations.mokosh` via
+     `$(hostname)`.
+6. Roles come up. Verify mail/vault/blog/etc. Update DNS to point at the
+   droplet IP.
+7. Decommission old VPS once verification passes.
+
+## Edge cases
+
+- **Local QEMU test boot.** `datasource_list = [ "DigitalOcean" "None" ]`
+  prevents cloud-init from blocking on metadata when the image is booted
+  outside DO. Network simply doesn't come up; SSH-via-host-port-forward
+  works via the user network in QEMU using DHCP from QEMU's user-mode net —
+  noted that this requires a small override module if needed for tests; not
+  blocking for the initial implementation.
+- **Root FS resize.** Only ext4 is supported by `autoResize`. Mokosh uses
+  ext4 (`machines/mokosh/default.nix:30`). Documented as a constraint of
+  `images/do-generic`.
+- **sshd before network.** Standard NixOS ordering: sshd's socket activation
+  binds after `network-online.target`. No special wiring required; cloud-init
+  brings up `ens3` (or whatever DO assigns) before that target completes.
+- **Stale image.** The image's only flake dependencies are the operator
+  pubkey, the cache pubkey, the channel pin, and the cloud-init / kernel
+  packages. A rebuild is only needed if any of those change materially.
+- **Secrets in image.** The image contains `secrets.hashedPassword` and
+  `secrets.sshKey` (public). Both already ship in every NixOS closure built
+  from this flake; no new exposure. No `/etc/nixos/secrets/*` content is
+  embedded.
+- **Hostname.** Empty `networking.hostName` in the image lets cloud-init set
+  it from droplet metadata. After `make switch` to mokosh, the flake sets
+  `mokosh` explicitly and wins.
+
+## Testing
+
+- `nix flake check` after wiring up the new config.
+- `nix build .#do-image` produces a non-empty qcow2.
+- QEMU smoke test:
+  ```
+  qemu-system-x86_64 \
+    -m 1024 -enable-kvm \
+    -drive file=result/nixos.qcow2,format=qcow2 \
+    -nic user,hostfwd=tcp::2222-:22
+  ssh -p 2222 o__ni@localhost
+  ```
+  Verify: boot completes, root FS expands, sshd answers, login works.
+- DO smoke test: upload to DO, create a $4–6/mo droplet, confirm cloud-init
+  populates networking, SSH in as `o__ni`, run `make switch` to apply
+  mokosh's role set, verify a couple of representative services
+  (`systemctl status nginx postfix dovecot vaultwarden`).
+
+## Documentation
+
+- New short section in `README.md` under "Adding a New Machine" titled
+  "Bootstrapping a DigitalOcean droplet" with the cutover steps.
+- Header comment in `images/do-generic/default.nix` describing scope (DO
+  hardware + cloud-init networking only; tooling and user belong elsewhere).
+
+## Out-of-scope follow-ups
+
+- Generic image variants for other providers (Hetzner, Vultr) under
+  `images/`.
+- Automating image upload to DO via `doctl` in CI.
+- A first-boot oneshot that auto-clones the flake and runs `nixos-rebuild
+  switch --flake .#$(hostname)` (the "hybrid" approach considered during
+  brainstorming).

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777396723,
-        "narHash": "sha256-WYbpNf5HYm05+23fpKEFd4RibJobITgtyYXtVOP+S/g=",
+        "lastModified": 1780430501,
+        "narHash": "sha256-nNjp1HJGnscx1lC/bagz4FfuUIPsq2lgkd93R3JBhr8=",
         "owner": "Kyure-A",
         "repo": "agent-skills-nix",
-        "rev": "3dadf974c87fd5b02a6d73bd67e354c02abb2c9f",
+        "rev": "ba550ebf77004b8a1f865528fc9a1d7e22628501",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775425411,
-        "narHash": "sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo=",
+        "lastModified": 1779506708,
+        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0d02ec1d0a05f88ef9e74b516842900c41f0f2fe",
+        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
         "type": "github"
       },
       "original": {
@@ -82,12 +82,15 @@
       }
     },
     "nixos-hardware": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
       "locked": {
-        "lastModified": 1776983936,
-        "narHash": "sha256-ZOQyNqSvJ8UdrrqU1p7vaFcdL53idK+LOM8oRWEWh6o=",
+        "lastModified": 1780310866,
+        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2096f3f411ce46e88a79ae4eafcfc9df8ed41c61",
+        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
         "type": "github"
       },
       "original": {
@@ -115,11 +118,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777548390,
-        "narHash": "sha256-WacE23EbHTsBKvr8cu+1DFNbP6Rh1brHUH5SDUI0NQI=",
+        "lastModified": 1780365719,
+        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7aaa00e7cc9be6c316cb5f6617bd740dd435c59d",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
         "type": "github"
       },
       "original": {
@@ -131,11 +134,24 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1767892417,
+        "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1780511130,
+        "narHash": "sha256-2v9lT4ya59Lh1FqPeLnz1MoX9y/wz2huqfe9RtQZITk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
         "type": "github"
       },
       "original": {
@@ -151,7 +167,7 @@
         "home-manager": "home-manager",
         "miniflux-summarizer": "miniflux-summarizer",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,12 @@
   };
 
   outputs =
-    { nixpkgs, nixpkgs-unstable, ... }@inputs:
+    {
+      self,
+      nixpkgs,
+      nixpkgs-unstable,
+      ...
+    }@inputs:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -93,6 +98,19 @@
         ];
       };
 
+      # generic DigitalOcean image (any x86_64 droplet)
+      nixosConfigurations."do-generic" = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        specialArgs = inputs;
+        modules = [
+          ./common/cache.nix
+          ./common/server.nix
+          ./users/o__ni
+          ./images/do-generic
+          { system.stateVersion = "25.11"; }
+        ];
+      };
+
       # standalone home-manager for macOS
       homeConfigurations."o__ni@Stepans-MacBook-Pro" = inputs.home-manager.lib.homeManagerConfiguration {
         pkgs = nixpkgsFor.aarch64-darwin;
@@ -148,6 +166,9 @@
         in
         {
           bulwark-webmail = pkgs.bulwark-webmail;
+        }
+        // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          do-image = self.nixosConfigurations."do-generic".config.system.build.digitalOceanImage;
         }
       );
     };

--- a/images/do-generic/default.nix
+++ b/images/do-generic/default.nix
@@ -1,0 +1,44 @@
+# Generic DigitalOcean-bootable NixOS profile.
+#
+# Scope: hardware/boot/network only. No users, tooling, or roles — those come
+# from other modules (e.g. users/o__ni, common/server.nix). Importing this
+# module exposes `system.build.digitalOceanImage` (a qcow2 builder) and wires
+# the runtime bits a droplet needs: virtio drivers, growpart on the root
+# partition, and cloud-init for networking from DO metadata.
+#
+# Constraint: root filesystem must be ext4 (autoResize uses online ext4 resize).
+
+{ modulesPath, lib, ... }:
+
+{
+  imports = [
+    "${modulesPath}/virtualisation/digital-ocean-image.nix"
+  ];
+
+  boot = {
+    growPartition = true;
+
+    initrd.availableKernelModules = [
+      "virtio_pci"
+      "virtio_scsi"
+      "virtio_blk"
+      "sd_mod"
+    ];
+  };
+
+  fileSystems."/".autoResize = true;
+
+  networking = {
+    useDHCP = false;
+    hostName = lib.mkDefault "";
+  };
+
+  services.cloud-init = {
+    enable = true;
+    network.enable = true;
+    settings.datasource_list = [
+      "DigitalOcean"
+      "None"
+    ];
+  };
+}

--- a/images/do-generic/default.nix
+++ b/images/do-generic/default.nix
@@ -26,8 +26,6 @@
     ];
   };
 
-  fileSystems."/".autoResize = true;
-
   networking = {
     useDHCP = false;
     hostName = lib.mkDefault "";

--- a/machines/mokosh/default.nix
+++ b/machines/mokosh/default.nix
@@ -8,7 +8,6 @@ let
     secondary = "uspenskiy.tech";
   };
   ifname = "ens3";
-  ip = (import ../../secrets).ip.mokosh;
   filterProxyUsersForHost = import ../../common/filter-proxy-users.nix { inherit lib; };
   secrets = import ../../secrets;
   users = filterProxyUsersForHost hostname secrets.singBoxUsers;
@@ -18,11 +17,9 @@ in
     ../../common/cache.nix
     ../../common/hardened.nix
     ../../common/server.nix
-    ../../hardware/vm.nix
+    ../../images/do-generic
     ../../roles
   ];
-
-  boot.loader.grub.device = "/dev/vda";
 
   # disk layout
   fileSystems = {
@@ -37,23 +34,8 @@ in
   # network
   networking = {
     hostName = hostname;
-    useDHCP = false;
     nameservers = [ "1.1.1.1" ];
     firewall.enable = true;
-
-    interfaces."${ifname}" = {
-      ipv4.addresses = [
-        {
-          address = ip.address;
-          prefixLength = 24;
-        }
-      ];
-    };
-
-    defaultGateway = {
-      address = ip.gateway;
-      interface = ifname;
-    };
   };
 
   services.openssh.settings = {

--- a/users/o__ni/default.nix
+++ b/users/o__ni/default.nix
@@ -1,8 +1,5 @@
 { pkgs, ... }:
 
-let
-  secrets = import ../../secrets;
-in
 {
   nix.settings.experimental-features = [
     "flakes"
@@ -31,7 +28,9 @@ in
       htop
     ];
 
-    hashedPassword = secrets.hashedPassword;
-    openssh.authorizedKeys.keys = [ secrets.sshKey ];
+    hashedPassword = "$6$XcCZkywz$BKCmi6.12Oe5s17ixN8GFbRmfv2E1/SrLQO9FNnJ4gDJI5sxJGXSKNCEF8Msur3U9mbwCXj4aepkRWetMCYx3.";
+    openssh.authorizedKeys.keys = [
+      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCnGEbhc1huuqNEF4PVgkdRqBWwB1SdG51Jt/XoHAA8gBc2h/SqKVwuumGT0tKZR4fhZ3Au2Iz3zTKrVj0bhqOiC3eDVK3rlWtn+Ts0QSx3LIUY474pmKITbeG5nyYEz1FjhpuanlUtnykSXRCmUaQGl1a4ULgyQf2l0cMriM0e4MVZmkf6i+rm9JC3/jz75WHQg2AJiJsV0ZNQeVim20Jufod1mg9K9Eqr8cdV09APvhgjs3/MiPqmqeDcLGTJgaNfEtOG+W2gjYVN0QFdB3ERy9C+r/55BQONZzIFwHjt/DvlWF+Ca6kuK0SkPk3VqV2C+NxCKrZrojLv7TmFn4kFhJbN/pHunJnFpLXdvmWPLAg1qZ5LKRrY83JKX4hPcWNuuEHeEe0V2RBa1E6V7dJtEOPdQYxv8lOyR0HeKvX4iQPy+PHj756URygxUWW0kP6Z46rwUeTsdaOSrlqRdrs7hvfi5BPImfx3nlBV2GXOwz7lIV0DXKm9BGTYrCxqw7GNLgZge0c0Cws4UzXkabDt1gXXWngxUr0heLNaMCe+u2SFVBnIEUvJ1QmljNBNGiLWZdqdgJtZrdNJX3GqJoE5W39+1lGnA0UDq28k+duFsXh+ojzGhb0BA3Sevc5d5W7BomZeg6t3rtnF+CvCf3uVCGlNwIM5XG33NRc7hO2WxQ== o__ni@Stepans-MacBook-Pro.local"
+    ];
   };
 }


### PR DESCRIPTION
## Summary

- Add `images/do-generic/` — a generic DO-bootable NixOS profile (virtio drivers, growpart via upstream, cloud-init for DO metadata networking)
- Wire `nixosConfigurations.do-generic` and `packages.x86_64-linux.do-image` into `flake.nix`; expose the qcow2 builder as a flake package
- Stage mokosh cutover: replace `hardware/vm.nix` with `images/do-generic`, drop static IP block (cloud-init takes over), update README with bootstrap runbook

## Notes

- `make check` passes — both `do-generic` and `mokosh` evaluate cleanly
- The `do-image` build (actual qcow2) requires an x86_64 Linux host or remote builder; not run in CI
- **Do not merge the mokosh commit until the droplet is provisioned and verified** — it drops the static IP and will break the on-prem VPS if applied prematurely

## Test Plan

- [ ] `make check` exits 0 on a machine with secrets unlocked
- [ ] `nix build 'path:.#do-image'` on an x86_64 Linux host produces `result/nixos.qcow2`
- [ ] Upload image to DO → Custom Images, create droplet, SSH in as `o__ni`
- [ ] `sudo make switch` on the droplet converges to the mokosh config
- [ ] Verify services: `systemctl status nginx postfix dovecot vaultwarden`
- [ ] Merge to main only after droplet is verified and DNS updated