### PR TITLE
feat(home): vendor shared agent skills

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,6 +23,22 @@
         "type": "github"
       }
     },
+    "dotnet-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783649988,
+        "narHash": "sha256-ytKFV7K9Xombw24GCP/rsX1rnvenmnAcAXpJwYgnj4c=",
+        "owner": "dotnet",
+        "repo": "skills",
+        "rev": "52ba152ed6e3a80cac59bf4f9827a3ed555292e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dotnet",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -208,12 +224,30 @@
     "root": {
       "inputs": {
         "agent-skills": "agent-skills",
+        "dotnet-skills": "dotnet-skills",
         "home-manager": "home-manager",
         "miniflux-summarizer": "miniflux-summarizer",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "nixvim": "nixvim"
+        "nixvim": "nixvim",
+        "superpowers": "superpowers"
+      }
+    },
+    "superpowers": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783029415,
+        "narHash": "sha256-kHdQ9e44doBk2yYW88tMSCqVG8ycYcvJSZlrIziXhpA=",
+        "owner": "obra",
+        "repo": "superpowers",
+        "rev": "d884ae04edebef577e82ff7c4e143debd0bbec99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "obra",
+        "repo": "superpowers",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,14 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.home-manager.follows = "home-manager";
     };
+    superpowers = {
+      url = "github:obra/superpowers";
+      flake = false;
+    };
+    dotnet-skills = {
+      url = "github:dotnet/skills";
+      flake = false;
+    };
     nixvim = {
       url = "github:nix-community/nixvim/nixos-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -126,8 +134,11 @@
             software.alacritty.enable = true;
             theme.name = "one-dark";
             software.neovim.enable = true;
-            codingAgents.claude.enable = true;
-            codingAgents.opencode.enable = true;
+            codingAgents = {
+              claude.enable = true;
+              opencode.enable = true;
+              codex.enable = true;
+            };
           }
         ];
       };

--- a/home/coding-agents/default.nix
+++ b/home/coding-agents/default.nix
@@ -32,5 +32,6 @@ in
   options.codingAgents = {
     claude = toolOpts cfg.claude.enable;
     opencode = toolOpts cfg.opencode.enable;
+    codex = toolOpts cfg.codex.enable;
   };
 }

--- a/home/coding-agents/instructions/default.nix
+++ b/home/coding-agents/instructions/default.nix
@@ -4,6 +4,7 @@ let
   cfg = config.codingAgents;
   enableClaude = cfg.claude.enable && cfg.claude.instructions;
   enableOpencode = cfg.opencode.enable && cfg.opencode.instructions;
+  enableCodex = cfg.codex.enable && cfg.codex.instructions;
 in
 {
   config = {
@@ -11,6 +12,9 @@ in
       source = ./AGENTS.md;
     };
     home.file.".config/opencode/AGENTS.md" = lib.mkIf enableOpencode {
+      source = ./AGENTS.md;
+    };
+    home.file.".codex/AGENTS.md" = lib.mkIf enableCodex {
       source = ./AGENTS.md;
     };
   };

--- a/home/coding-agents/skills/default.nix
+++ b/home/coding-agents/skills/default.nix
@@ -5,8 +5,9 @@ let
 
   claudeEnabled = cfg.claude.enable && cfg.claude.skills;
   opencodeEnabled = cfg.opencode.enable && cfg.opencode.skills;
-  anyTargetEnabled = claudeEnabled || opencodeEnabled;
-  hasAllowlist = cfg.skills.enable != [ ];
+  codexEnabled = cfg.codex.enable && cfg.codex.skills;
+  anyTargetEnabled = claudeEnabled || opencodeEnabled || codexEnabled;
+  hasSelection = cfg.skills.enableAll != [ ] || cfg.skills.enable != [ ];
 in
 {
   options.codingAgents.skills = {
@@ -31,6 +32,14 @@ in
         "<idPrefix>/<skill-name>". Skills not on the allowlist are not deployed.
       '';
     };
+    enableAll = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Enable every discovered skill from the named sources. An empty list
+        disables source-wide selection.
+      '';
+    };
   };
 
   config = {
@@ -39,18 +48,89 @@ in
         path = ./own;
         idPrefix = "own";
       };
+      superpowers = {
+        input = "superpowers";
+        subdir = "skills";
+        idPrefix = "superpowers";
+      };
+      dotnet = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet/skills";
+        idPrefix = "dotnet";
+      };
+      dotnet-advanced = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet-advanced/skills";
+        idPrefix = "dotnet-advanced";
+      };
+      dotnet-data = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet-data/skills";
+        idPrefix = "dotnet-data";
+      };
+      dotnet-diag = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet-diag/skills";
+        idPrefix = "dotnet-diag";
+      };
+      dotnet-msbuild = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet-msbuild/skills";
+        idPrefix = "dotnet-msbuild";
+      };
+      dotnet-nuget = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet-nuget/skills";
+        idPrefix = "dotnet-nuget";
+      };
+      dotnet-upgrade = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet-upgrade/skills";
+        idPrefix = "dotnet-upgrade";
+      };
+      dotnet-ai = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet-ai/skills";
+        idPrefix = "dotnet-ai";
+      };
+      dotnet-test = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet-test/skills";
+        idPrefix = "dotnet-test";
+      };
+      dotnet-aspnetcore = {
+        input = "dotnet-skills";
+        subdir = "plugins/dotnet-aspnetcore/skills";
+        idPrefix = "dotnet-aspnetcore";
+      };
     };
 
-    programs.agent-skills = lib.mkIf (anyTargetEnabled && hasAllowlist) {
+    codingAgents.skills.enableAll = [
+      "superpowers"
+      "dotnet"
+      "dotnet-advanced"
+      "dotnet-data"
+      "dotnet-diag"
+      "dotnet-msbuild"
+      "dotnet-nuget"
+      "dotnet-upgrade"
+      "dotnet-ai"
+      "dotnet-test"
+      "dotnet-aspnetcore"
+    ];
+
+    programs.agent-skills = lib.mkIf (anyTargetEnabled && hasSelection) {
       enable = true;
       sources = cfg.skills.sources;
       skills.enable = cfg.skills.enable;
+      skills.enableAll = cfg.skills.enableAll;
       targets.claude.enable = claudeEnabled;
       targets.opencode = {
         enable = opencodeEnabled;
         dest = "$HOME/.config/opencode/skills";
         structure = "symlink-tree";
       };
+      targets.codex.enable = codexEnabled;
     };
   };
 }

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   pkgs,
-  config,
   ...
 }:
 


### PR DESCRIPTION
## Summary

- Pin obra/superpowers and dotnet/skills as Flake inputs.
- Enable all Superpowers skills.
- Enable all skills from the requested .NET plugin roots.
- Deploy the shared bundle to Claude, OpenCode, and Codex targets.

## Validation

- nix flake check 'path:.' --all-systems
- Home Manager activation build for o__ni@Stepans-MacBook-Pro
- Home Manager activation build for o__ni@DodoBook.local
- Generated bundle contains 80 skills.