### PR TITLE
feat(home): add coding-agent skills

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,6 +99,22 @@
         "type": "github"
       }
     },
+    "mattpocock-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784629731,
+        "narHash": "sha256-o/H9s3t6ahBqFwpkOMBOTwpsvb33pgvpI9n0PA+uLYM=",
+        "owner": "mattpocock",
+        "repo": "skills",
+        "rev": "ed37663cc5fbef691ddfecd080dff42f7e7e350d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
     "miniflux-summarizer": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -201,6 +217,7 @@
         "agent-skills": "agent-skills",
         "dotnet-skills": "dotnet-skills",
         "home-manager": "home-manager",
+        "mattpocock-skills": "mattpocock-skills",
         "miniflux-summarizer": "miniflux-summarizer",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,10 @@
       url = "github:dotnet/skills";
       flake = false;
     };
+    mattpocock-skills = {
+      url = "github:mattpocock/skills";
+      flake = false;
+    };
     nixvim = {
       url = "github:nix-community/nixvim/nixos-26.05";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/home/coding-agents/skills/default.nix
+++ b/home/coding-agents/skills/default.nix
@@ -95,10 +95,23 @@ in
         input = "dotnet-skills";
         subdir = "plugins/dotnet-aspnetcore/skills";
       };
+      mattpocock-engineering = {
+        input = "mattpocock-skills";
+        subdir = "skills/engineering";
+        filter.maxDepth = 1;
+      };
+      mattpocock-productivity = {
+        input = "mattpocock-skills";
+        subdir = "skills/productivity";
+        filter.maxDepth = 1;
+      };
     };
 
     codingAgents.skills.enableAll = [
+      "own"
       "superpowers"
+      "mattpocock-engineering"
+      "mattpocock-productivity"
       "dotnet"
       "dotnet-advanced"
       "dotnet-data"

--- a/home/coding-agents/skills/own/humanize-text/SKILL.md
+++ b/home/coding-agents/skills/own/humanize-text/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: humanize-text
+description: Use when rewriting text that sounds AI-generated or formulaic — uniform sentence lengths, symmetrical structures, banned filler phrases — to sound natural and human-authored, while preserving every fact, argument, and authorial voice.
+---
+
+# Humanize Text
+
+## Overview
+
+Rewrite text so it reads as written by a living person. Preserve all meaning, facts, and tone; change only surface-level patterns that mark machine authorship.
+
+This is a **flexible** skill — adapt the techniques to genre and register, don't apply mechanically.
+
+## Preserve (change nothing)
+
+- All facts, numbers, names, dates
+- Overall structure and argumentative logic
+- Tone (academic, conversational, journalistic, etc.)
+- Author's own terms and specialized vocabulary
+
+## Change (for humanization)
+
+| Technique | How |
+|---|---|
+| **Sentence length variation** | Mix short and long sentences chaotically — no two adjacent sentences the same length |
+| **Rhythm breaks** | After a long sentence — short. Sharp. Alive. |
+| **Natural connectives** | Insert sparingly: "worth noting", "notably", "at first glance", "which matters", "it's telling that" |
+| **No parallel symmetry** | Break up lists and anaphora that feel constructed — humans rarely sustain perfect parallelism |
+| **Intentional informality** | Once or twice, use a slightly less "correct" but natural phrasing for the register |
+| **Rhetorical questions** | Add 1–2 if the genre permits; skip entirely in strictly formal texts |
+
+## Forbidden Words (Russian)
+
+These are AI-text markers — replace or restructure any sentence that contains them:
+
+`таким образом` · `безусловно` · `несомненно` · `данный` · `осуществляется` · `в рамках` · `на сегодняшний день`
+
+**Replacements:** `данный` → `этот`; `таким образом` → restructure the sentence; `на сегодняшний день` → `сейчас`, `сегодня`, or cut.
+
+## Forbidden Actions
+
+- Adding new facts or changing existing ones
+- Altering the meaning of any paragraph
+- Removing the author's key arguments
+- Using the banned words above as replacements for other banned words
+
+## Final Check (before returning)
+
+1. Read the text aloud mentally — stumbling is good, means it sounds human
+2. Confirm no two consecutive sentences have the same length
+3. Confirm no repeating syntactic constructions in adjacent paragraphs
+4. Scan for any surviving banned words
+
+## Example
+
+**Before (AI-typical):**
+> Таким образом, данный инструмент осуществляет управление контентом. Безусловно, это упрощает работу с рабочим пространством. Несомненно, подобный подход оправдан.
+
+**After:**
+> Инструмент берёт на себя управление контентом — и это меняет то, как вы работаете с пространством. Подход, на первый взгляд, простой. Но именно простота здесь и работает.


### PR DESCRIPTION
## Summary
- Add pinned `mattpocock/skills` input and enable all engineering/productivity skills.
- Add the local `humanize-text` skill to the shared Home Manager catalog.
- Keep the installed skill layout flat for Claude Code and OpenCode compatibility.

## Validation
- `make check`
- Home Manager activation package build for `o__ni@Stepans-MacBook-Pro`
- Home Manager activation package build for `o__ni@DodoBook.local`